### PR TITLE
allow matching against data in the form of url params for GET requests

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -55,6 +55,10 @@
 							var identical = false;
 							// Deep inspect the identity of the objects
 							(function ident(mock, live) {
+                                                                if (typeof live === 'string') {
+                                                                  identical = $.isFunction( mock.test ) ? mock.test(live) : mock == live;
+                                                                  return identical;
+                                                                }
 								$.each(mock, function(k, v) {
 									if ( live[k] === undefined ) {
 										identical = false;


### PR DESCRIPTION
It would be really nice if the data was split into a params hash and the matchers could match against individual pieces. Thats a larger fix. 
