### PR TITLE
Fixed return value of $.ajax

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -197,7 +197,7 @@
 						complete();
 						return false;
 					}
-					_ajax.call($, $.extend(true, {}, origSettings, {
+					mock = _ajax.call($, $.extend(true, {}, origSettings, {
 						// Mock the XHR object
 						xhr: function() {
 							// Extend with our default mockjax settings
@@ -285,6 +285,8 @@
 			// We don't have a mock request, trigger a normal request
 			if ( !mock ) {
 				return _ajax.apply($, arguments);
+			} else {
+				return mock;
 			}
 		}
 	});

--- a/test_mockjax.js
+++ b/test_mockjax.js
@@ -1,0 +1,15 @@
+module("mockjax");
+test("should return xmlhttprequest object", function() {
+    stop();
+    $.mockjax({
+        url: '/myapi',
+        responseTest: "Hello Word"
+    });
+    var xhr = $.ajax({
+        url: '/myapi',
+        complete: function() {
+            start();
+        }
+    });
+    ok(xhr, "xhr object should not be null/undefined");
+});

--- a/tests.html
+++ b/tests.html
@@ -1,0 +1,19 @@
+<!DOCTYPE HTML>
+<html>
+    <head>
+        <script type="text/javascript" src="http://code.jquery.com/jquery-latest.js"></script>
+        <link rel="stylesheet" href="http://github.com/jquery/qunit/raw/master/qunit/qunit.css" type="text/css" media="screen" />
+        <script type="text/javascript" src="http://github.com/jquery/qunit/raw/master/qunit/qunit.js"></script>
+        <script type="text/javascript" src="jquery.mockjax.js"></script>
+        <title>MockJax Tests</title>
+      </head>
+    <body>
+        <h1 id="qunit-header">MockJax</h1>
+        <h2 id="qunit-banner"></h2>
+        <h2 id="qunit-userAgent"></h2>
+        <ol id="qunit-tests"></ol>
+
+        <script type="text/javascript" src="test_mockjax.js"></script>
+
+    </body>
+</html>


### PR DESCRIPTION
If a mock is defined, $.ajax don't return (fake) xhr object. I fixed that. 

I also added a very tiny testsuite.

Any comments ?
François
