### PR TITLE
Better log message	 

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -95,7 +95,7 @@
 				}
 				if ( m ) {
 					if ( typeof console !== 'undefined' && console.log ) {
-						console.log('MOCK GET: ' + s.url);
+						console.log('MOCK ' + s.type + ': ' + s.url);
 					}
 					mock = true;
 					


### PR DESCRIPTION
Please pull b4889b45, logs "MOCK <type>: <url>" instead of confusing "MOCK GET: <url>" at for all types of requests.
