### PR TITLE
Use GET to fetch json files when using proxy

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -240,7 +240,7 @@
 										_ajax({
 											global: false,
 											url: m.proxy,
-											type: m.type,
+											type: "GET", // Always use GET to load json mock files
 											data: m.data,
 											dataType: s.dataType,
 											complete: function(xhr, txt) {


### PR DESCRIPTION
Hi,

I'd like to have this change pulled in, it fixes the issue with the proxy call using the mock VERB instead of GET to load the mock json files.

Hope you like it.

Thanks
Sebastien
