### PR TITLE
Unit tests fail with jquery 1.5

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -206,6 +206,7 @@
 							return {
 								status: m.status,
 								readyState: 1,
+							  getAllResponseHeaders: function() { },
 								open: function() { },
 								send: function() {
 									var process = $.proxy(function() {


### PR DESCRIPTION
Woke up this morning and upgraded my application to jquery 1.5. I was very sad to see mockjax was broken with jquery 1.5. I did some quick investigation and found that it was an easy fix. The XHR object you were creating was missing getAllResponseHeaders function. I added an empty function definition to the mock XHR object and the test passes with jquery 1.5 and my application worked with mockjax and jquery 1.5.

Thanks!
