### PR TITLE
set status in the dynamic response function

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -272,6 +272,9 @@
 												} else {
 													this.responseText = m.responseText;
 												}
+                        if( typeof m.status == 'number' || typeof m.status == 'string' ) {
+                          this.status = m.status;
+                        }
 												// jQuery < 1.4 doesn't have onreadystate change for xhr
 												if ( $.isFunction(this.onreadystatechange) ) {
 													this.onreadystatechange( m.isTimeout ? 'timeout' : undefined );

--- a/test/test.js
+++ b/test/test.js
@@ -44,6 +44,7 @@ asyncTest('Intercept and proxy (sub-ajax request)', function() {
 	
 	$.mockjaxClear();
 });
+
 asyncTest('Dynamic response callback', function() {
 	$.mockjax({
 		url: '/response-callback',
@@ -67,6 +68,31 @@ asyncTest('Dynamic response callback', function() {
 	
 	$.mockjaxClear();
 });
+
+asyncTest('Dynamic response status callback', function() {
+	$.mockjax({
+		url: '/response-callback',
+		response: function(settings) {
+      this.status = 500;
+		}
+	});
+	
+	$.ajax({
+		url: '/response-callback',
+		dataType: 'text',
+		data: {
+			response: 'Hello world'
+		},
+		error: function(){ ok(true, "error callback was called"); },
+		complete: function(xhr) {
+			equals(xhr.status, 500, 'Dynamically set response status matches');
+			start();
+		}
+	});
+	
+	$.mockjaxClear();
+});
+
 test('Remove mockjax definition by id', function() {
 	var id = $.mockjax({
 		url: '/test',


### PR DESCRIPTION
allows to set the status in the response function ... I had this need and I guess other people could use this as well (somebody was asking for random status codes).
Stupid example which could be handles by the ulr pattern ... just to have an example (this.status = ... is the important part):

```
$.mockjax({
  url: 'http://' + location.host + '/users/*',
  responseTime: 0,
  dataType: 'json',
  response: function(settings) {
    this.responseText = {
      username: settings.url.replace(/.*\//,""), // get the username from the url
    };
    this.status = this.username == "foo" ? 500 : 200;
  }
});
```
