### PR TITLE
allows custom set headers to be inspected

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -242,6 +242,9 @@
 							// Extend with our default mockjax settings
 							m = $.extend({}, $.mockjaxSettings, m);
 
+							if (typeof m.headers === 'undefined') {
+								m.headers = {};
+							}
 							if ( m.contentType ) {
 								m.headers['content-type'] = m.contentType;
 							}
@@ -317,7 +320,9 @@
 								abort: function() {
 									clearTimeout(this.responseTimer);
 								},
-								setRequestHeader: function() { },
+								setRequestHeader: function(header, value) {
+									m.headers[header] = value;
+								},
 								getResponseHeader: function(header) {
 									// 'Last-modified', 'Etag', 'content-type' are all checked by jQuery
 									if ( m.headers && m.headers[header] ) {

--- a/test/test.js
+++ b/test/test.js
@@ -464,6 +464,32 @@ asyncTest('Response time simulation and latency', function() {
 	}, 30);
 });
 
+module('Headers');
+asyncTest('headers can be inspected via setRequestHeader()', function() {
+	var mock;
+	$('html').ajaxSend(function(event, xhr, ajaxSettings) {
+		xhr.setRequestHeader('X-CSRFToken', '<this is a token>');
+	});
+	mock = $.mockjax({
+		url: '/inspect-headers',
+		response: function(settings) {
+			var key;
+			if (typeof this.headers['X-Csrftoken'] !== 'undefined') {
+				key = 'X-Csrftoken';  // bugs in jquery 1.5
+			} else {
+				key = 'X-CSRFToken';
+			}
+			equals(this.headers[key], '<this is a token>');
+			$.mockjaxClear(mock);
+			start();
+		}
+	});
+	$.ajax({
+		url: '/inspect-headers',
+		complete: function() {}
+	});
+});
+
 
 // TODO: SIMULATING HTTP RESPONSE STATUSES
 // TODO: SETTING THE CONTENT-TYPE


### PR DESCRIPTION
Hi.  This patch was needed to test custom code that calls `xhr.setRequestHeader()`, like this:

```
$('html').ajaxSend(function(event, xhr, ajaxSettings) {
    if (!/^https?:/.test(ajaxSettings.url)) {
        // Only send the token to relative URLs i.e. locally.
        csrf = $.cookie('csrftoken') || $("#csrfmiddlewaretoken").val();
        xhr.setRequestHeader("X-CSRFToken", csrf);
    }
});
```
