### PR TITLE
Proxy requests should have status too

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -291,6 +291,7 @@
 											complete: function(xhr, txt) {
 												m.responseXML = xhr.responseXML;
 												m.responseText = xhr.responseText;
+												m.status = xhr.status;
 												this.responseTimer = setTimeout(process, m.responseTime || 0);
 											}
 										});


### PR DESCRIPTION
We found a case where a proxy request could return a 404. This fix allows that status to be passed through, instead of responding as 'success' for all proxy requests.
