### PR TITLE
Make it so that ajax request mocks are synchronous if responseTime is set to 0

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -230,7 +230,7 @@
 						complete();
 						return false;
 					}
-					mock = _ajax.call($, $.extend(true, {}, origSettings, {
+					_ajax.call($, $.extend(true, {}, origSettings, {
 						// Mock the XHR object
 						xhr: function() {
 							// Extend with our default mockjax settings


### PR DESCRIPTION
Sometimes you don't care about the response time for an AJAX request and simply want to check that certain functionality is triggered when the request succeeds or fails.

Asynchronous tests add complication to your tests if this is the case.

With that in mind, I feel that setting the responseTime to 0 when setting up mockjax should mean that the test is actually synchronous. Given the default responseTime is 200 this change shouldn't break any existing uses of this library.

The second commit in this pull request is a weird bug (at least I think it's a bug) I discovered in mockjax, that I created a jsfiddle URL to demonstrate (in the commit message). The mock variable was being set to the result of calling _ajax, which was null (even though it had actually mocked the request) and thus it triggered another (actual) AJAX request. I should note that the bug only became apparent after my first commit when using this new synchronous mocking functionality.

Also, while I'm at it the documentation should probably be updated to make it clearer that you can specify the data attribute in your mockjax setup and it will do a comparison against the request that is made. Similarly, for the fact that the original request data is passed into the response function.
