### PR TITLE
Document log function

### DIFF
--- a/docs/simpledoc.xml
+++ b/docs/simpledoc.xml
@@ -77,7 +77,8 @@ $.mockjaxClear(id);
   responseXML:   [string],
   proxy:         [string],
   lastModified:  [date string],
-  etag:          [string]
+  etag:          [string],
+  log:           [function]
 };
 				]]></block>
 			</code>
@@ -118,6 +119,9 @@ $.mockjaxClear(id);
 			<attribute name="etag">
 				<description>A string specifying a unique identifier referencing a specific version of the requested data. This is used by $.ajax to determine if the requested data is new since the last request. (see http://en.wikipedia.org/wiki/HTTP_ETag)</description>
 			</attribute>
+			<attribute name="log">
+				<description>A function called with log messages.</description>
+			</attribute>
 		</section>		
 		
 		<section name="Global MockjaxSettings">
@@ -141,7 +145,8 @@ $.mockjaxSettings = {
   responseXML:   '',
   proxy:         '',
   lastModified:  null,
-  etag:          ''
+  etag:          '',
+  log:           function(msg) { window['console'] && window.console.log && window.console.log(msg); }
 };
 ]]>
 				</block>


### PR DESCRIPTION
For one of my projects, I'm mocking a long-polling server with mockjax requests that have 1s response times. Unfortunately this meant lots of console logs. The log option isn't currently documented, so I was about to write my own, and then ran into it in the source. Can we add it to the documentation?

Thanks!
