### PR TITLE
Replace wildcard matching with RegExp, allowing matching to be much more...

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ check this list:
 * `$.mockjax(options)`
   * Sets up a mockjax handler.
   * `options`: An object literal which defines the settings to use for the mocked request.
-      * `url`: A string specifying the url of the request that the data should be mocked for. If the url contains an asterisk ( * ), it is treated as a wildcard and the url will attempt to match any request to a url similar to the portion of the url **before** the asterisk.
+      * `url`: A string or regular expression specifying the url of the request that the data should be mocked for. If the url is a string and contains an asterisk ( * ), it is treated as a wildcard, by translating to a regular expression, replacing the asterisk with `.+`.
       * `data`: In addition to the URL, match parameters.
       * `type`: Specify what HTTP method to match, usually GET or POST. Case-insensitive, so `get` and `post` also work.
       * `headers`: An object literal whos keys will be simulated as additional headers returned from the server for the request.

--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -79,10 +79,8 @@
 					} else {
 						// Look for a simple wildcard '*' or a direct URL match
 						var star = m.url.indexOf('*');
-						if ( ( m.url != '*' && m.url != s.url && star == -1 ) ||
-							( star > -1 && m.url.substr(0, star) != s.url.substr(0, star) ) ) {
-							 // The url we tested did not match the wildcard *
-							 m = null;
+						if (m.url !== s.url && star === -1 || !new RegExp(m.url.replace(/[-[\]{}()+?.,\\^$|#\s]/g, "\\$&").replace('*', '.+')).test(s.url)) {
+							m = null;
 						}
 					}
 					if ( m ) {

--- a/test/test.js
+++ b/test/test.js
@@ -233,20 +233,25 @@ asyncTest('Exact string', function() {
 
 	$.mockjaxClear();
 });
-asyncTest('Wildcard match', 1, function() {
-	$.mockjax({
-		url: '/wildcard/string/*',
-		responseText: 'wildcard string'
-	});
-
-	$.ajax({
-		url: '/wildcard/string/123456',
-		error: noErrorCallbackExpected,
-		complete: function(xhr) {
-			equals(xhr.responseText, 'wildcard string', 'Wildcard * string url match');
-			start();
-		}
-	});
+test('Wildcard match', 4, function() {
+	function mock(mockUrl, url, response) {
+		$.mockjax({
+			url: mockUrl,
+			responseText: response
+		});
+		$.ajax({
+			async: false,
+			url: url,
+			error: noErrorCallbackExpected,
+			complete: function(xhr) {
+				equals(xhr.responseText, response);
+			}
+		});
+	}
+	mock('/wildcard*w', '/wildcard/123456/w', 'w');
+	mock('/wildcard*x', '/wildcard/123456/x', 'x');
+	mock('*y', '/wildcard/123456/y', 'y');
+	mock('z*', 'z/wildcard/123456', 'z');
 
 	$.mockjaxClear();
 });


### PR DESCRIPTION
... flexible. Escapes the given URL before replacing the asterisk with the regex matching code, then matches against the given URL. Fixes #36
