### PR TITLE
Variable rquery is not defined in the source.

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -142,7 +142,7 @@
 					if ( s.dataType === "jsonp" ) {
 						if ( s.type.toUpperCase() === "GET" ) {
 							if ( !jsre.test( s.url ) ) {
-								s.url += (rquery.test( s.url ) ? "&" : "?") + (s.jsonp || "callback") + "=?";
+								s.url += (/\?/.test( s.url ) ? "&" : "?") + (s.jsonp || "callback") + "=?";
 							}
 						} else if ( !s.data || !jsre.test(s.data) ) {
 							s.data = (s.data ? s.data + "&" : "") + (s.jsonp || "callback") + "=?";


### PR DESCRIPTION
rquery regexp has not been imported from the jQuery source, so it should be replaced with original regexp. We get js error otherwise.
