### PR TITLE
Added test using jQuery Deferred callbacks and isTimeout

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -843,6 +843,32 @@ asyncTest('Forcing timeout', function() {
 
 	$.mockjaxClear();
 });
+// FORCE SIMULATION OF SERVER TIMEOUTS WITH PROMISES
+asyncTest('Forcing timeout with Promises', function() {
+	$.mockjax({
+		url: '/response-callback',
+		responseText: 'done',
+		isTimeout: true
+	});
+
+	var request = $.ajax({
+		url: '/response-callback'
+	});
+
+    request.done(function(xhr) {
+        ok(true, "error callback was called");
+    });
+    
+    request.fail(function(response) {
+        ok(false, "should not be be successful");
+    });
+    
+    request.always(function(xhr) {
+        start();
+    });
+    
+	$.mockjaxClear();
+});
 // DYNAMICALLY GENERATING MOCK DEFINITIONS
 asyncTest('Dynamic mock definition', function() {
 	$.mockjax( function( settings ) {


### PR DESCRIPTION
Described in issue #63

Currently the test fails because on line 181 of jquery.mockjax.js, a call is made to requestSettings.error(), but no such function exists.
