### PR TITLE
Fixed isTimeout issue for deferred-style ajax requests. Fixes #63

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -171,15 +171,14 @@
 						this.statusText = mockHandler.statusText;
 					}
 					// jQuery < 1.4 doesn't have onreadystate change for xhr
-					if ( $.isFunction(this.onreadystatechange) && !mockHandler.isTimeout ) {
+					if ( $.isFunction(this.onreadystatechange) ) {
+						if( mockHandler.isTimeout) {
+							this.status = -1;
+						}
 						this.onreadystatechange( mockHandler.isTimeout ? 'timeout' : undefined );
 					} else if ( mockHandler.isTimeout ) {
-						if ( $.isFunction( $.handleError ) ) {
-							// Fix for 1.3.2 timeout to keep success from firing.
-							this.readyState = -1;
-						}
-						requestSettings.error( this, "timeout" );
-						requestSettings.complete( this, "timeout" );
+						// Fix for 1.3.2 timeout to keep success from firing.
+						this.status = -1;
 					}
 				}).apply(that);
 			};

--- a/test/test.js
+++ b/test/test.js
@@ -844,31 +844,33 @@ asyncTest('Forcing timeout', function() {
 	$.mockjaxClear();
 });
 // FORCE SIMULATION OF SERVER TIMEOUTS WITH PROMISES
-asyncTest('Forcing timeout with Promises', function() {
-	$.mockjax({
-		url: '/response-callback',
-		responseText: 'done',
-		isTimeout: true
-	});
 
-	var request = $.ajax({
-		url: '/response-callback'
-	});
+if(jQuery.Deferred) {
+	asyncTest('Forcing timeout with Promises', function() {
+		$.mockjax({
+			url: '/response-callback',
+			isTimeout: true,
+		});
 
-    request.done(function(xhr) {
-        ok(true, "error callback was called");
-    });
-    
-    request.fail(function(response) {
-        ok(false, "should not be be successful");
-    });
-    
-    request.always(function(xhr) {
-        start();
-    });
-    
-	$.mockjaxClear();
-});
+		var request = $.ajax({
+			url: '/response-callback'
+		});
+
+		request.done(function(xhr) {
+			ok(false, "Should not be successful");
+		});
+
+		request.fail(function(response) {
+			ok(true, "error callback was called");
+		});
+
+		request.complete(function(xhr) {
+			start();
+		});
+
+		$.mockjaxClear();
+	});
+}
 // DYNAMICALLY GENERATING MOCK DEFINITIONS
 asyncTest('Dynamic mock definition', function() {
 	$.mockjax( function( settings ) {


### PR DESCRIPTION
This fix also changes some of the behavior of timeouts, namely it no longer manually calls error or complete on timeout. Instead, it lets jQuery handle that, as it should.

Also changes some spaces to tabs in the original pull request.
