### PR TITLE
Fixed the jsonp callback context error.

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -31,7 +31,7 @@
 		}
 
 		try {
-			var xmlDoc 	= ( new DOMParser() ).parseFromString( xml, 'text/xml' );
+			var xmlDoc	= ( new DOMParser() ).parseFromString( xml, 'text/xml' );
 			if ( $.isXMLDoc( xmlDoc ) ) {
 				var err = $('parsererror', xmlDoc);
 				if ( err.length == 1 ) {
@@ -142,9 +142,9 @@
 			return function() {
 				return (function() {
 					// The request has returned
-					this.status 		= mockHandler.status;
+					this.status			= mockHandler.status;
 					this.statusText		= mockHandler.statusText;
-					this.readyState 	= 4;
+					this.readyState		= 4;
 
 					// We have an executable function, call it to give
 					// the mock handler a chance to update it's data
@@ -270,7 +270,7 @@
 
 		requestSettings.dataType = "json";
 		if(requestSettings.data && CALLBACK_REGEX.test(requestSettings.data) || CALLBACK_REGEX.test(requestSettings.url)) {
-			createJsonpCallback(requestSettings, mockHandler);
+			createJsonpCallback(requestSettings, mockHandler, origSettings);
 
 			// We need to make sure
 			// that a JSONP style response is executed properly
@@ -328,8 +328,8 @@
 		}
 
 		// Successful response
-		jsonpSuccess( requestSettings, mockHandler );
-		jsonpComplete( requestSettings, mockHandler );
+		jsonpSuccess( requestSettings, callbackContext, mockHandler );
+		jsonpComplete( requestSettings, callbackContext, mockHandler );
 
 		// If we are running under jQuery 1.5+, return a deferred object
 		if(jQuery.Deferred){
@@ -346,7 +346,8 @@
 
 
 	// Create the required JSONP callback function for the request
-	function createJsonpCallback( requestSettings, mockHandler ) {
+	function createJsonpCallback( requestSettings, mockHandler, origSettings ) {
+		var callbackContext = origSettings && origSettings.context || requestSettings;
 		jsonp = requestSettings.jsonpCallback || ("jsonp" + jsc++);
 
 		// Replace the =? sequence both in the query string and the data
@@ -360,8 +361,8 @@
 		// Handle JSONP-style loading
 		window[ jsonp ] = window[ jsonp ] || function( tmp ) {
 			data = tmp;
-			jsonpSuccess( requestSettings, mockHandler );
-			jsonpComplete( requestSettings, mockHandler );
+      jsonpSuccess( requestSettings, callbackContext, mockHandler );
+      jsonpComplete( requestSettings, callbackContext, mockHandler );
 			// Garbage collect
 			window[ jsonp ] = undefined;
 
@@ -376,7 +377,7 @@
 	}
 
 	// The JSONP request was successful
-	function jsonpSuccess(requestSettings, mockHandler) {
+	function jsonpSuccess(requestSettings, callbackContext, mockHandler) {
 		// If a local callback was specified, fire it and pass it the data
 		if ( requestSettings.success ) {
 			requestSettings.success.call( callbackContext, ( mockHandler.response ? mockHandler.response.toString() : mockHandler.responseText || ''), status, {} );
@@ -389,7 +390,7 @@
 	}
 
 	// The JSONP request was completed
-	function jsonpComplete(requestSettings, mockHandler) {
+	function jsonpComplete(requestSettings, callbackContext, mockHandler) {
 		// Process result
 		if ( requestSettings.complete ) {
 			requestSettings.complete.call( callbackContext, {} , status );
@@ -481,7 +482,7 @@
 		//type:       'GET',
 		log:          function(msg) {
 										window['console'] && window.console.log && window.console.log(msg);
-					  			},
+									},
 		status:       200,
 		statusText:   "OK",
 		responseTime: 500,
@@ -518,4 +519,4 @@
 			return mockHandlers[i];
 		}
 	};
-})(jQuery);
+})(self.jQuery);


### PR DESCRIPTION
It was just a few undeclared variables.  It's done poorly.  Perhaps the callbackContext should be part of an object and made available via that...  or perhaps more global so all the functions can access it....

I just passed the callbackContext around.  I like this approach less than putting it all in an object, but more than a more global closure variable...

To each their own...
