### PR TITLE
Pass all arguments to console.log passed to the log function

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -479,9 +479,11 @@
 	$.mockjaxSettings = {
 		//url:        null,
 		//type:       'GET',
-		log:          function(msg) {
-										window['console'] && window.console.log && window.console.log(msg);
-					  			},
+		log:          function( msg ) {
+			if ( window[ 'console' ] && window.console.log ) {
+				window.console.log.apply( console, arguments );
+			}
+		},
 		status:       200,
 		statusText:   "OK",
 		responseTime: 500,


### PR DESCRIPTION
The log function was not passing all of it's parameters to console.log, so I changed it to do so. This will work nicely in Chrome & Safari by keeping the same message as now & adding an object with tons of properties about the request. It works decent in Firefox too, but it will stringify the 2nd object. IE won't stringify the 2nd parameter and it will show up as "[object]", which kind of stinks. 

This Pull Request is to address Issue #72.
