### PR TITLE
just added deferred support suggestestion for issue #45

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -136,7 +136,7 @@
 
 	// Process the xhr objects send operation
 	function _xhrSend(mockHandler, requestSettings, origSettings) {
-
+    var that = this;
 		// This is a substitute for < 1.4 which lacks $.proxy
 		var process = (function(that) {
 			return function() {
@@ -204,7 +204,7 @@
        mockHandler
           .done(function (res) {
             mockHandler.responseText = JSON.stringify(res);
-            process();
+				    that.responseTimer = setTimeout(process, mockHandler.responseTime || 50);
           });
 
     } else {


### PR DESCRIPTION
I just implemented something to get me deferred-responses working. I am using it in my coffeescript application like this

``` coffeescript
$.mockjax (settings) ->
  df = new $.Deferred()
  if settings.headers?['X-Amz-Target']
    serviceTarget = settings.headers['X-Amz-Target']
    console.log 'mocking service target:', serviceTarget
    targetFunction = serviceTarget.split('.').pop()
    window.charlie.service[targetFunction](settings.data)
      .done (result) =>
        df.resolve result
    return df
  else
    return

think this could be useful. if anybody is interested i would add some tests to it, so we can go further with this suggestion. what do you think?
```
