### PR TITLE
Object mockHandler now deeply extended from config objects in xhr()

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -214,7 +214,7 @@
 	// Construct a mocked XHR Object
 	function xhr(mockHandler, requestSettings, origSettings, origHandler) {
 		// Extend with our default mockjax settings
-		mockHandler = $.extend({}, $.mockjaxSettings, mockHandler);
+		mockHandler = $.extend(true, {}, $.mockjaxSettings, mockHandler);
 
 		if (typeof mockHandler.headers === 'undefined') {
 			mockHandler.headers = {};


### PR DESCRIPTION
Object mockHandler now deeply extended from config objects in xhr(). Fixes #76.
More information [here](https://github.com/appendto/jquery-mockjax/issues/76).
