### PR TITLE
Make log function work in IE8

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -517,6 +517,10 @@
 		//type:       'GET',
 		log:          function( msg ) {
 			if (window['console'] && window.console.log) {
+				if (!Function.prototype.bind) {
+					console.log(Array.prototype.slice.call(arguments).join(', '));
+					return;
+				}
 				var log = Function.prototype.bind.call(console.log, console);
 				log.apply(console, arguments);
 			}


### PR DESCRIPTION
IE8 does not have `Function.prototype.bind`. In that case log directly by calling `console.log`.
