### PR TITLE
added request headers matching

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -109,6 +109,29 @@
 			}
 		}
 
+        // Inspect the request headers submitted
+        if ( handler.requestHeaders )
+        {
+            console.log("checking headers");
+            if (requestSettings.headers == undefined)
+            {
+                console.log("no headers");
+                return null;
+            }
+            else
+            {
+                for (header in handler.requestHeaders)
+                {
+                    var h = requestSettings.headers[header];
+                    if(h == undefined )
+                        return null;
+                    if(h !== handler.requestHeaders[header])
+                        return null;
+                    
+                }
+            }
+        }
+
 		// Inspect the data submitted in the request (either POST body or GET query string)
 		if ( handler.data && requestSettings.data ) {
 			if ( !isMockDataEqual(handler.data, requestSettings.data) ) {

--- a/test/test.js
+++ b/test/test.js
@@ -338,6 +338,97 @@ asyncTest('Case-insensitive matching for request types', function() {
     $.mockjaxClear();
 });
 
+module('Headers Matching');
+asyncTest('Not equal headers', function() {
+    $.mockjax({
+        url: '/exact/string',
+        requestHeaders: {
+            Authorization: "12345"
+        },
+        responseText: 'Exact headers'
+    });
+
+    $.ajax({
+        url: '/exact/string',
+        error: function() { ok(true, "Error called on bad request headers matching"); },
+        success: function() { ok(false, "Success should not be called"); },
+        complete: function(xhr) {
+            start();
+        }
+    });
+
+    $.mockjaxClear();
+});
+asyncTest('Not equal headers values', function() {
+    $.mockjax({
+        url: '/exact/string',
+        requestHeaders: {
+            Authorization: "12345"
+        },
+        responseText: 'Exact headers'
+    });
+
+    $.ajax({
+        url: '/exact/string',
+        headers: {
+            Authorization: "6789"
+        },
+        error: function() { ok(true, "Error called on bad request headers matching"); },
+        success: function() { ok(false, "Success should not be called"); },
+        complete: function(xhr) {
+            start();
+        }
+    });
+
+    $.mockjaxClear();
+});
+asyncTest('Not equal multiple headers', function() {
+    $.mockjax({
+        url: '/exact/string',
+        requestHeaders: {
+            Authorization: "12345",
+            MyHeader: "hello"
+        },
+        responseText: 'Exact headers'
+    });
+
+    $.ajax({
+        url: '/exact/string',
+        headers: {
+            Authorization: "12345"
+        },
+        error: function() { ok(true, "Error called on bad request headers matching"); },
+        success: function() { ok(false, "Success should not be called"); },
+        complete: function(xhr) {
+            start();
+        }
+    });
+
+    $.mockjaxClear();
+});
+asyncTest('Exact headers keys and values', function() {
+    $.mockjax({
+        url: '/exact/string',
+        requestHeaders: {
+            Authorization: "12345"
+        },
+        responseText: 'Exact headers'
+    });
+
+    $.ajax({
+        url: '/exact/string',
+        error: noErrorCallbackExpected,
+        headers: {
+            Authorization: "12345"
+        },
+        complete: function(xhr) {
+            equals(xhr.responseText, 'Exact headers', 'Exact headers keys and values');
+            start();
+        }
+    });
+
+    $.mockjaxClear();
+});
 module('URL Matching');
 asyncTest('Exact string', function() {
     $.mockjax({


### PR DESCRIPTION
Added the ability to match request headers.

I'm in the middle of testing some oauth2 services and I needed an easy way to create mocks which would be valid only if an `Authorization` header was sent in the request.

This pull requests adds a new property you can define in the mockjax options object called `requestHeaders`. 
`requestHeaders` is just an object with key, value pairs defining which headers are needed by the request to be validated.

here is an example which will match all the requests to /me only if the request includes an header called `Authorization` with value `"Bearer vsdfjsdf+adfvadfv="`

```
$.mockjax({
    url: "/me",
    requestHeaders: {
        Authorization: "Bearer vsdfjsdf+adfvadfv="
    },
    responseText: "YEAH!"
}
```
