### PR TITLE
Async calls inside "response"

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -149,6 +149,12 @@
 
 		// This is a substitute for < 1.4 which lacks $.proxy
 		var process = (function(that) {
+			// We have an executable function, call it to give
+			// the mock handler a chance to update it's data
+			if ( $.isFunction(mockHandler.response) ) {
+				mockHandler.response(origSettings);
+			}
+			
 			return function() {
 				return (function() {
 					// The request has returned
@@ -156,11 +162,6 @@
 					this.statusText		= mockHandler.statusText;
 					this.readyState 	= 4;
 
-					// We have an executable function, call it to give
-					// the mock handler a chance to update it's data
-					if ( $.isFunction(mockHandler.response) ) {
-						mockHandler.response(origSettings);
-					}
 					// Copy over our mock to our xhr object before passing control back to
 					// jQuery's onreadystatechange callback
 					if ( requestSettings.dataType == 'json' && ( typeof mockHandler.responseText == 'object' ) ) {


### PR DESCRIPTION
My use case looks something like this:

``` javascript
'use strict';

var _postLogin, _stubs;
_stubs = myApp.stubs;

_postLogin = $.mockjax({
    type : 'post',
    url : '/api/login',
    response : function (settings) {
    var _email, _passphrase, that;

    _email = settings.data.email;
        _passphrase = settings.data.passphrase;

        that = this;

        _stubs.db.login(_email, _passphrase, function (result) {

            that.responseText = result;

        });
    }
});

_stubs.postLogin = _postLogin;
```

The problem is that I want to be able to set the response text as part of a callback, sent to my stubbed database. Because under the hood mockjax executed the handler after a set timeout period, there wasn't really a good way of simulating that exchange. By moving where the handler was executed to before the timeout, nothing is lost, but we can deal with this kind of scenario.
