### PR TITLE
fixed leaked global var in createJsonpCallback

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -355,7 +355,7 @@
 
 	// Create the required JSONP callback function for the request
 	function createJsonpCallback( requestSettings, mockHandler ) {
-		jsonp = requestSettings.jsonpCallback || ("jsonp" + jsc++);
+		var jsonp = requestSettings.jsonpCallback || ("jsonp" + jsc++);
 
 		// Replace the =? sequence both in the query string and the data
 		if ( requestSettings.data ) {


### PR DESCRIPTION
`jsonp` was being leaked
