### PR TITLE
Fix jsonp when setting responseText in response

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -388,7 +388,7 @@
 	function jsonpSuccess(requestSettings, callbackContext, mockHandler) {
 		// If a local callback was specified, fire it and pass it the data
 		if ( requestSettings.success ) {
-			requestSettings.success.call( callbackContext, ( mockHandler.response ? mockHandler.response.toString() : mockHandler.responseText || ''), status, {} );
+			requestSettings.success.call( callbackContext, mockHandler.responseText || "", status, {} );
 		}
 
 		// Fire the global callback

--- a/test/test.js
+++ b/test/test.js
@@ -1054,6 +1054,29 @@ asyncTest( 'Test bug fix for $.mockjaxSettings', function() {
 
     $.mockjaxClear();
 });
+
+asyncTest("Preserve responseText inside a response function when using jsonp and a success callback", function(){
+    $.mockjax({
+        url: "http://some/fake/jsonp/endpoint",
+        // The following line works...
+        // responseText: [{ "data" : "JSONP is cool" }]
+        // But doesn't not work when setting this.responseText in response
+        response: function() {
+            this.responseText = [{ "data" : "JSONP is cool" }];
+        }
+    });
+
+    $.ajax({
+        url: "http://some/fake/jsonp/endpoint",
+        dataType: "jsonp",
+        success: function(data) {
+            deepEqual(data, [{ "data" : "JSONP is cool" }]);
+            start();
+        }
+    });
+
+    $.mockjaxClear();
+});
 /*
 var id = $.mockjax({
    ...


### PR DESCRIPTION
When trying to mock a JSONP request using the response mockjax option the data returned in the $.ajax success callback is incorrect. Instead of being the data from responseText it is the toString'ed version of the response function.

I've included a unit test recreating the issue and have fixed mockjax to work appropriately. 
