### PR TITLE
Synchronous Callbacks 

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -196,16 +196,21 @@
 					mockHandler.responseText = xhr.responseText;
 					mockHandler.status = xhr.status;
 					mockHandler.statusText = xhr.statusText;
-					this.responseTimer = setTimeout(process, mockHandler.responseTime || 0);
+					if ( requestSettings.async === false || mockHandler.responseTime < 0) {
+						// TODO: Blocking delay
+						process();
+					} else {
+						this.responseTimer = setTimeout(process, mockHandler.responseTime);
+					}
 				}
 			});
 		} else {
 			// type == 'POST' || 'GET' || 'DELETE'
-			if ( requestSettings.async === false ) {
+			if ( requestSettings.async === false || mockHandler.responseTime < 0) {
 				// TODO: Blocking delay
 				process();
 			} else {
-				this.responseTimer = setTimeout(process, mockHandler.responseTime || 50);
+				this.responseTimer = setTimeout(process, mockHandler.responseTime);
 			}
 		}
 	}


### PR DESCRIPTION
This changes callbacks to skip the use of the timer when responseTime is less than zero.
I found it helpful when mocking everything to write tests more procedurally.
