### PR TITLE
Support responseTime setting for JSONP.

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -327,8 +327,10 @@
 		}
 
 		// Successful response
-		jsonpSuccess( requestSettings, callbackContext, mockHandler );
-		jsonpComplete( requestSettings, callbackContext, mockHandler );
+		setTimeout(function() {
+			jsonpSuccess( requestSettings, callbackContext, mockHandler );
+			jsonpComplete( requestSettings, callbackContext, mockHandler );
+		}, mockHandler.responseTime || 0)
 
 		// If we are running under jQuery 1.5+, return a deferred object
 		if($.Deferred){


### PR DESCRIPTION
The `responseTime` setting was only taking affect for JSON requests. This change makes it work for JSONP requests as well.
