### PR TITLE
Don't override a custom status when using proxy data

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -69,7 +69,7 @@
 				identical = false;
 				return identical;
 			} else {
-				// This will allow to compare Arrays 
+				// This will allow to compare Arrays
 				if ( typeof live[k] === 'object' && live[k] !== null ) {
 					identical = identical && isMockDataEqual(mock[k], live[k]);
 				} else {
@@ -84,6 +84,11 @@
 
 		return identical;
 	}
+
+    // See if a mock handler property matches the default settings
+    function isDefaultSetting(handler, property) {
+        return handler[property] === $.mockjaxSettings[property];
+    }
 
 	// Check the given handler should mock the given request
 	function getMockForRequest( handler, requestSettings ) {
@@ -194,8 +199,14 @@
 				complete: function(xhr) {
 					mockHandler.responseXML = xhr.responseXML;
 					mockHandler.responseText = xhr.responseText;
-					mockHandler.status = xhr.status;
-					mockHandler.statusText = xhr.statusText;
+                    // Don't override the handler status/statusText if it's specified by the config
+                    if (isDefaultSetting(mockHandler, 'status')) {
+					    mockHandler.status = xhr.status;
+                    }
+                    if (isDefaultSetting(mockHandler, 'statusText')) {
+					    mockHandler.statusText = xhr.statusText;
+                    }
+
 					this.responseTimer = setTimeout(process, mockHandler.responseTime || 0);
 				}
 			});

--- a/test/test.js
+++ b/test/test.js
@@ -1163,6 +1163,29 @@ asyncTest("Preserve responseText inside a response function when using jsonp and
 
     $.mockjaxClear();
 });
+
+asyncTest('Custom status when using proxy', function() {
+    $.mockjax({
+        url: '/response-callback',
+        status: 409,
+        proxy: 'test_proxy.json'
+    });
+
+    $.ajax({
+        url: '/response-callback',
+        error: function(){ ok(true, "error callback was called"); },
+        success: function(json) {
+            ok( false, "Success should not be called" );
+        },
+        complete: function(xhr) {
+            equals(xhr.status, 409, 'response status matches');
+            start();
+        }
+    });
+
+    $.mockjaxClear();
+});
+
 /*
 var id = $.mockjax({
    ...


### PR DESCRIPTION
This change should allow users to mock REST services that return entity data along with 400-range error codes. When using proxy data, mockjax will only use the proxy status and statusText when the mock handler is using the default settings. This should keep the existing behavior for users that rely on custom status codes from the proxy.
