### PR TITLE
use original data object when the mock data is empty

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -460,9 +460,10 @@
 				}
 			}
 
-
-			// Removed to fix #54 - keep the mocking data object intact
-			//mockHandler.data = requestSettings.data;
+			// use original data object if the mock data is empty
+			if (typeof mockHandler.data === "undefined") {
+				mockHandler.data = requestSettings.data;
+			}
 
 			mockHandler.cache = requestSettings.cache;
 			mockHandler.timeout = requestSettings.timeout;


### PR DESCRIPTION
Hello,

I'm using mockjax on my project. This is very useful library!

BTW, I think mockjax should pass through the original data object when the mock data is empty.

``` javasript

// Set proxy only
$.mockjax({
    url: "/foo",
    proxy: "/bar"
});

// This will call /bar?test=test
$.ajax({
   url: "/foo",
   type: 'GET',
   data: {
      test: "test"
   }
});
```

What do you think?

Thanks,
westzaki
