### PR TITLE
Correctly match between multiple mocks for the same url when request has no data property

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -115,8 +115,8 @@
 		}
 
 		// Inspect the data submitted in the request (either POST body or GET query string)
-		if ( handler.data && requestSettings.data ) {
-			if ( !isMockDataEqual(handler.data, requestSettings.data) ) {
+		if ( handler.data ) {
+			if ( ! requestSettings.data || !isMockDataEqual(handler.data, requestSettings.data) ) {
 				// They're not identical, do not mock this request
 				return null;
 			}

--- a/test/test.js
+++ b/test/test.js
@@ -535,6 +535,38 @@ asyncTest('Correct data matching on request with empty object literals', 1, func
     $.mockjaxClear();
 });
 
+asyncTest('Correct matching on request without data and mocks with and without data but same url', 1, function() {
+    $.mockjax({
+        url: '/response-callback',
+        data: {
+          foo: 'bar'
+        },
+        responseText: 'false match'
+    });
+    $.mockjax({
+        url: '/response-callback',
+        responseText: 'correct match'
+    });
+    $.mockjax({
+        url: '/response-callback',
+        data: {
+          bar: 'foo'
+        },
+        responseText: 'another false match'
+    });
+
+    $.ajax({
+        url: '/response-callback',
+        error: noErrorCallbackExpected,
+        complete: function(xhr) {
+            equals(xhr.responseText, 'correct match', 'Matched with correct mock');
+            start();
+        }
+    });
+
+    $.mockjaxClear();
+});
+
 // Related issue #68
 asyncTest('Correct data matching on request with arrays', 1, function() {
     $.mockjax({


### PR DESCRIPTION
Given a mock with the data property defined and a mock with the same url property but without the data property defined, when presented with a request for the url that has no data property defined, then match the mock without the data property defined
