### PR TITLE
Correct parameters for trigger jsonp complete

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -410,7 +410,7 @@
 
 		// The request was completed
 		if ( requestSettings.global ) {
-			trigger( "ajaxComplete", [{}, requestSettings] );
+			trigger( requestSettings, "ajaxComplete", [{}, requestSettings] );
 		}
 
 		// Handle the global AJAX counter


### PR DESCRIPTION
This fixes unit tests in Internet Explorer 8.

I just used the same signature of the previous method `jsonpSuccess`.

It fails in IE8 because mockjax tries to call `.indexOf` on the Array instead of the `ajaxComplete` string.

I wanted to create a test where any browser fails, but I couldn't make sense out of it.

The test should:
- make a jsonp request
- verify that both `ajaxSuccess` and `ajaxComplete` events are triggered globally (the latter is not)

However
1. Those events are raised after the `complete` callback, so I'm not sure where to put the assert
2. [This page](http://api.jquery.com/category/ajax/global-ajax-event-handlers/) says that:
   
   > Global events are never fired for cross-domain script or JSONP requests, regardless of the value of global

So maybe when using JSONP those events should not be triggered at all...

**tl;dr**

I just decided to fix IE8 errors
