### PR TITLE
Fixed test for jsonp mock call checking in jquery 1.4.4

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -326,18 +326,26 @@ asyncTest('Get mocked ajax calls - POST with data', function() {
 
 asyncTest('Get mocked ajax calls - JSONP', function() {
     $.mockjax({
-        url: '/api/example/*'
+        url: '/api/example/*',
+        contentType: 'text/json',
+        proxy: 'test_jsonp.js'
     });
+    var callbackExecuted = false;
+    window.abcdef123456 = function(json) {
+        ok( true, 'JSONP Callback executed');
+        callbackExecuted = true;
+    };
 
-    $.ajax({
-        async: false,
+    var ret = $.ajax({
         url: '/api/example/jsonp?callback=?',
-        jsonpCallback: 'foo123',
+        jsonpCallback: 'abcdef123456',
         dataType: 'jsonp',
-        complete: function() {
+        error: noErrorCallbackExpected,
+        complete: function(xhr) {
             var actualCalls = $.mockjax.mockedAjaxCalls();
             equal(actualCalls.length, 1, 'Mockjax call made');
-            equal(actualCalls[0].url, '/api/example/jsonp?callback=foo123', 'mockjax call has expected jsonp url');
+            equal(actualCalls[0].url, '/api/example/jsonp?callback=abcdef123456', 'mockjax call has expected jsonp url');
+            ok(callbackExecuted, 'The jsonp callback was executed');
             start();
         }
     });


### PR DESCRIPTION
Basically, jQuery 1.4.x simply does not like JSONP requests unless all settings are proper, otherwise it silently fails. This fix should allow for the tests to be properly executed.
