### PR TITLE
Added fix for #131 by changing request headers to be placed on ...

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -231,6 +231,12 @@
 		if (typeof mockHandler.headers === 'undefined') {
 			mockHandler.headers = {};
 		}
+		if (typeof requestSettings.headers === 'undefined') {
+			requestSettings.headers = {};
+		}
+		if (typeof origSettings.headers === 'undefined') {
+			origSettings.headers = {};
+		}
 		if ( mockHandler.contentType ) {
 			mockHandler.headers['content-type'] = mockHandler.contentType;
 		}
@@ -248,7 +254,10 @@
 				clearTimeout(this.responseTimer);
 			},
 			setRequestHeader: function(header, value) {
-				requestSettings.headers[header] = value;
+				// we need to place this request header on both objects 
+				// since this 'xhr' object is acting as the real thing from the 
+				// POV of the calling code
+				requestSettings.headers[header] = origSettings.headers[header] = value;
 			},
 			getResponseHeader: function(header) {
 				// 'Last-modified', 'Etag', 'content-type' are all checked by jQuery

--- a/test/test.js
+++ b/test/test.js
@@ -1056,12 +1056,12 @@ asyncTest('headers can be inspected via setRequestHeader()', function() {
         url: '/inspect-headers',
         response: function(settings) {
             var key;
-            if (typeof this.headers['X-Csrftoken'] !== 'undefined') {
+            if (settings.headers && typeof settings.headers['X-Csrftoken'] !== 'undefined') {
                 key = 'X-Csrftoken';  // bugs in jquery 1.5
             } else {
                 key = 'X-CSRFToken';
             }
-            equal(this.headers[key], '<this is a token>');
+            equal(settings.headers && settings.headers[key], '<this is a token>');
             start();
         }
     });


### PR DESCRIPTION
...requestSettings object instead of mockHandler, which is, essentially, the response settings.

@dcneiner or @jcreamer898 quick review would be appeciated, it's a 1-line change, but want to make sure it's correct.
