### PR TITLE
Test fixes for jQuery 1.9+

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -693,7 +693,6 @@ asyncTest('Correct data matching on request with arrays', 1, function() {
   $.ajax({
     url: '/response-callback',
     error: function(xhr, status) {
-    	console.log(status);
       ok( false, "Error callback fired" );
     },
     data: {


### PR DESCRIPTION
jQuery 1.9+ does not like undefined responseText (results in `parsererror`).
