### PR TITLE
Tech Debt: Use `throw new Error("message")` syntax

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -36,10 +36,10 @@
 			if ( $.isXMLDoc( xmlDoc ) ) {
 				var err = $('parsererror', xmlDoc);
 				if ( err.length == 1 ) {
-					throw('Error: ' + $(xmlDoc).text() );
+					throw new Error('Error: ' + $(xmlDoc).text() );
 				}
 			} else {
-				throw('Unable to parse XML');
+				throw new Error('Unable to parse XML');
 			}
 			return xmlDoc;
 		} catch( e ) {
@@ -485,7 +485,7 @@
 
 		// We don't have a mock request
 		if($.mockjaxSettings.throwUnmocked === true) {
-			throw('AJAX not mocked: ' + origSettings.url);
+			throw new Error('AJAX not mocked: ' + origSettings.url);
 		}
 		else { // trigger a normal request
 			return _ajax.apply($, [origSettings]);


### PR DESCRIPTION
Updated the use of `throw("message")` to `throw new Error("message")` I
was motivated to do this primarily because of the issue raised [here](https://github.com/emberjs/ember.js/issues/5366)
raising errors in this way will not only allow Ember applications to
utilize the `throwUnmocked` setting but should provide a consistent
error raising experience across all major browsers as detailed
[here](http://www.nczonline.net/blog/2009/03/10/the-art-of-throwing-javascript-errors-part-2/)

I would like to provide a test for this but I am unsure how we could go
about doing that. This does not introduce any regressions and should be
a more universal way of doing it.
