### PR TITLE
Bug Fix: unfiredHandlers function excludes null handlers

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -605,7 +605,7 @@
 		var results = [];
 		for (var i=0, len=mockHandlers.length; i<len; i++) {
 			var handler = mockHandlers[i];
-			if (!handler.fired) {
+            if (handler !== null && !handler.fired) {
 				results.push(handler);
 			}
 		}

--- a/test/test.js
+++ b/test/test.js
@@ -324,6 +324,31 @@ asyncTest('Get unfired handlers', function() {
     });
 });
 
+asyncTest('Get unfired handlers after calling mockjaxClear', function() {
+    $.mockjax({
+        url: '/api/example/1'
+    });
+    $.mockjax({
+        url: '/api/example/2'
+    });
+    $.mockjax({
+        url: '/api/example/3'
+    });
+
+    $.ajax({
+        async: false,
+        type: 'GET',
+        url: '/api/example/1',
+        complete: function() {
+            $.mockjaxClear(2)
+            var handlersNotFired = $.mockjax.unfiredHandlers();
+            equal(handlersNotFired.length, 1, 'all mocks were fired');
+            equal(handlersNotFired[0].url, '/api/example/2', 'mockjax call has unexpected url');
+            start();
+        }
+    });
+});
+
 asyncTest('Response settings correct using PUT method', function() {
 	$.mockjax({
 		url: '/put-request',


### PR DESCRIPTION
If $.mockjaxClear was called on a specific handler setting it to null we
need to exclude those from what the unfiredHandlers function looks at.
Also added a test to show this failed before and works now
