### PR TITLE
Adds main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "jquery-mockjax",
   "version": "1.5.4",
+  "main": "jquery.mockjax.js",
   "description": "Mockjax. The jQuery Mockjax Plugin provides a simple and extremely flexible interface for mocking or simulating ajax requests and responses.",
   "url": "http://code.appendto.com/plugins/jquery-mockjax/",
   "keywords": [ "ajax", "mock", "unit" ],


### PR DESCRIPTION
This allows developers to use mockjax with a CommonJS builder like webpack. Presently the package can't be resolved, so webpack throws an error.

I'd love to see this get pushed as a bug fix ASAP :) Let me know if there's anything else I can do.
