### PR TITLE
Convert to $.mockjax.clear() format

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -627,7 +627,7 @@
 	};
 	// support older, deprecated version
 	$.mockjaxClear = function(i) {
-		$.mockjaxSettings.log( 'DEPRECATED: The $.mockjaxClear() method has been deprecated in 1.6.0. Please use $.mockjax.clear() as the older function will be removed soon!' );
+		window.console && window.console.warn && window.console.warn( 'DEPRECATED: The $.mockjaxClear() method has been deprecated in 1.6.0. Please use $.mockjax.clear() as the older function will be removed soon!' );
 		$.mockjax.clear();
 	};
 	$.mockjax.handler = function(i) {

--- a/test/test.js
+++ b/test/test.js
@@ -280,6 +280,16 @@ asyncTest('Clearing mockjax removes all handlers', function() {
 	});
 });
 
+test('Old version of clearing mock handlers works', function() {
+	$.mockjax({
+		url: '/api/example/1'
+	});
+
+	$.mockjaxClear();
+
+	equal($.mockjax.handler(0), undefined, 'There are no mock handlers');
+});
+
 // asyncTest('Intercept log messages', function() {
 //	 var msg = null;
 //	 $.mockjaxSettings.log = function(inMsg, settings) {


### PR DESCRIPTION
This is PR implements #42 and provides for a consistent interface. There are no breaking changes as the old method (`$.mockjaxClear()`) simply points to the new method with a deprecation notice.
