### PR TITLE
added request headers matcher

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -117,12 +117,11 @@
 			//No expectation for headers, do not mock this request
 			if (requestSettings.headers === undefined) {
 				return null;
-			}
-			else {
+			} else {
 				var headersMismatch = false;
 				$.each(handler.requestHeaders, function(key, value) {
 					var v = requestSettings.headers[key];
-					if(v === undefined || v !== value) {
+					if(v !== value) {
 						headersMismatch = true;
 						return false;
 					}

--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -113,24 +113,24 @@
 		}
 
 		// Inspect the request headers submitted
-		if ( handler.requestHeaders )
-		{
+		if ( handler.requestHeaders ) {
 			//No expectation for headers, do not mock this request
-			if (requestSettings.headers === undefined)
-			{
+			if (requestSettings.headers === undefined) {
 				return null;
 			}
-			else
-			{
+			else {
 				var headersMismatch = false;
 				$.each(handler.requestHeaders, function(key, value) {
 					var v = requestSettings.headers[key];
-					if(v === undefined || v !== value)
+					if(v === undefined || v !== value) {
 						headersMismatch = true;
+						return false;
+					}
 				});
 				//Headers do not match, do not mock this request
-				if (headersMismatch)
+				if (headersMismatch) {
 					return null;
+				}
 			}
 		}
 

--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -112,6 +112,28 @@
 			}
 		}
 
+		// Inspect the request headers submitted
+		if ( handler.requestHeaders )
+		{
+			//No expectation for headers, do not mock this request
+			if (requestSettings.headers === undefined)
+			{
+				return null;
+			}
+			else
+			{
+				var headersMismatch = false;
+				$.each(handler.requestHeaders, function(key, value) {
+					var v = requestSettings.headers[key];
+					if(v === undefined || v !== value)
+						headersMismatch = true;
+				});
+				//Headers do not match, do not mock this request
+				if (headersMismatch)
+					return null;
+			}
+		}
+
 		// Inspect the data submitted in the request (either POST body or GET query string)
 		if ( handler.data ) {
 			if ( ! requestSettings.data || !isMockDataEqual(handler.data, requestSettings.data) ) {

--- a/test/test.js
+++ b/test/test.js
@@ -699,122 +699,121 @@ asyncTest('Case-insensitive matching for request types', function() {
 	});
 });
 
-
 module('Headers Matching');
 asyncTest('Not equal headers', function() {
-    $.mockjax({
-        url: '/exact/string',
-        requestHeaders: {
-            Authorization: "12345"
-        },
-        responseText: 'Exact headers'
-    });
+	$.mockjax({
+		url: '/exact/string',
+		requestHeaders: {
+			Authorization: "12345"
+		},
+		responseText: 'Exact headers'
+	});
 
-    $.ajax({
-        url: '/exact/string',
-        error: function() { ok(true, "Error called on bad request headers matching"); },
-        success: function() { ok(false, "Success should not be called"); },
-        complete: function(xhr) {
-            start();
-        }
-    });
-
-    $.mockjax.clear();
+	$.ajax({
+		url: '/exact/string',
+		error: function() { ok(true, "Error called on bad request headers matching"); },
+		success: function() { ok(false, "Success should not be called"); },
+		complete: function(xhr) {
+			var mockedAjaxCalls = $.mockjax.mockedAjaxCalls();
+			equal(mockedAjaxCalls.length, 0, 'No mocked Ajax calls should have been returned');
+			start();
+		}
+	});
 });
 asyncTest('Not equal headers values', function() {
-    $.mockjax({
-        url: '/exact/string',
-        requestHeaders: {
-            Authorization: "12345"
-        },
-        responseText: 'Exact headers'
-    });
+	$.mockjax({
+		url: '/exact/string',
+		requestHeaders: {
+			Authorization: "12345"
+		},
+		responseText: 'Exact headers'
+	});
 
-    $.ajax({
-        url: '/exact/string',
-        headers: {
-            Authorization: "6789"
-        },
-        error: function() { ok(true, "Error called on bad request headers matching"); },
-        success: function() { ok(false, "Success should not be called"); },
-        complete: function(xhr) {
-            start();
-        }
-    });
-
-    $.mockjax.clear();
+	$.ajax({
+		url: '/exact/string',
+		headers: {
+			Authorization: "6789"
+		},
+		error: function() { ok(true, "Error called on bad request headers matching"); },
+		success: function() { ok(false, "Success should not be called"); },
+		complete: function(xhr) {
+			var mockedAjaxCalls = $.mockjax.mockedAjaxCalls();
+			equal(mockedAjaxCalls.length, 0, 'No mocked Ajax calls should have been returned');
+			start();
+		}
+	});
 });
 asyncTest('Not equal multiple headers', function() {
-    $.mockjax({
-        url: '/exact/string',
-        requestHeaders: {
-            Authorization: "12345",
-            MyHeader: "hello"
-        },
-        responseText: 'Exact headers'
-    });
+	$.mockjax({
+		url: '/exact/string',
+		requestHeaders: {
+			Authorization: "12345",
+			MyHeader: "hello"
+		},
+		responseText: 'Exact headers'
+	});
 
-    $.ajax({
-        url: '/exact/string',
-        headers: {
-            Authorization: "12345"
-        },
-        error: function() { ok(true, "Error called on bad request headers matching"); },
-        success: function() { ok(false, "Success should not be called"); },
-        complete: function(xhr) {
-            start();
-        }
-    });
-
-    $.mockjax.clear();
+	$.ajax({
+		url: '/exact/string',
+		headers: {
+			Authorization: "12345"
+		},
+		error: function() { ok(true, "Error called on bad request headers matching"); },
+		success: function() { ok(false, "Success should not be called"); },
+		complete: function(xhr) {
+			var mockedAjaxCalls = $.mockjax.mockedAjaxCalls();
+			equal(mockedAjaxCalls.length, 0, 'No mocked Ajax calls should have been returned');
+			start();
+		}
+	});
 });
 asyncTest('Exact headers keys and values', function() {
-    $.mockjax({
-        url: '/exact/string',
-        requestHeaders: {
-            Authorization: "12345"
-        },
-        responseText: 'Exact headers'
-    });
+	$.mockjax({
+		url: '/exact/string',
+		requestHeaders: {
+			Authorization: "12345"
+		},
+		responseText: 'Exact headers'
+	});
 
-    $.ajax({
-        url: '/exact/string',
-        error: noErrorCallbackExpected,
-        headers: {
-            Authorization: "12345"
-        },
-        complete: function(xhr) {
-            equal(xhr.responseText, 'Exact headers', 'Exact headers keys and values');
-            start();
-        }
-    });
-
-    $.mockjax.clear();
+	$.ajax({
+		url: '/exact/string',
+		error: noErrorCallbackExpected,
+		headers: {
+			Authorization: "12345"
+		},
+		complete: function(xhr) {
+			var mockedAjaxCalls = $.mockjax.mockedAjaxCalls();
+			equal(mockedAjaxCalls.length, 1, 'A mocked Ajax calls should have been returned');
+			equal(xhr.responseText, 'Exact headers', 'Exact headers keys and values');
+			start();
+		}
+	});
 });
 asyncTest('Exact multiple headers keys and values', function() {
-    $.mockjax({
-        url: '/exact/string',
-        requestHeaders: {
-            Authorization: "12345",
-            MyHeader: "hello"
-        },
-        responseText: 'Exact multiple headers'
-    });
+	$.mockjax({
+		url: '/exact/string',
+		requestHeaders: {
+			Authorization: "12345",
+			MyHeader: "hello"
+		},
+		responseText: 'Exact multiple headers'
+	});
 
-    $.ajax({
-        url: '/exact/string',
-        error: noErrorCallbackExpected,
-        headers: {
-            Authorization: "12345",
-            MyHeader: "hello"
-        },
-        complete: function(xhr) {
-            equal(xhr.responseText, 'Exact multiple headers', 'Exact headers keys and values');
-            start();
-        }
-    });
-
-    $.mockjax.clear();
+	$.ajax({
+		url: '/exact/string',
+		error: noErrorCallbackExpected,
+		headers: {
+			Authorization: "12345",
+			MyHeader: "hello"
+		},
+		complete: function(xhr) {
+			var mockedAjaxCalls = $.mockjax.mockedAjaxCalls();
+			equal(mockedAjaxCalls.length, 1, 'A mocked Ajax calls should have been returned');
+			equal(xhr.responseText, 'Exact multiple headers', 'Exact headers keys and values');
+			start();
+		}
+	});
 });
 
 module('URL Matching');

--- a/test/test.js
+++ b/test/test.js
@@ -699,6 +699,124 @@ asyncTest('Case-insensitive matching for request types', function() {
 	});
 });
 
+
+module('Headers Matching');
+asyncTest('Not equal headers', function() {
+    $.mockjax({
+        url: '/exact/string',
+        requestHeaders: {
+            Authorization: "12345"
+        },
+        responseText: 'Exact headers'
+    });
+
+    $.ajax({
+        url: '/exact/string',
+        error: function() { ok(true, "Error called on bad request headers matching"); },
+        success: function() { ok(false, "Success should not be called"); },
+        complete: function(xhr) {
+            start();
+        }
+    });
+
+    $.mockjax.clear();
+});
+asyncTest('Not equal headers values', function() {
+    $.mockjax({
+        url: '/exact/string',
+        requestHeaders: {
+            Authorization: "12345"
+        },
+        responseText: 'Exact headers'
+    });
+
+    $.ajax({
+        url: '/exact/string',
+        headers: {
+            Authorization: "6789"
+        },
+        error: function() { ok(true, "Error called on bad request headers matching"); },
+        success: function() { ok(false, "Success should not be called"); },
+        complete: function(xhr) {
+            start();
+        }
+    });
+
+    $.mockjax.clear();
+});
+asyncTest('Not equal multiple headers', function() {
+    $.mockjax({
+        url: '/exact/string',
+        requestHeaders: {
+            Authorization: "12345",
+            MyHeader: "hello"
+        },
+        responseText: 'Exact headers'
+    });
+
+    $.ajax({
+        url: '/exact/string',
+        headers: {
+            Authorization: "12345"
+        },
+        error: function() { ok(true, "Error called on bad request headers matching"); },
+        success: function() { ok(false, "Success should not be called"); },
+        complete: function(xhr) {
+            start();
+        }
+    });
+
+    $.mockjax.clear();
+});
+asyncTest('Exact headers keys and values', function() {
+    $.mockjax({
+        url: '/exact/string',
+        requestHeaders: {
+            Authorization: "12345"
+        },
+        responseText: 'Exact headers'
+    });
+
+    $.ajax({
+        url: '/exact/string',
+        error: noErrorCallbackExpected,
+        headers: {
+            Authorization: "12345"
+        },
+        complete: function(xhr) {
+            equal(xhr.responseText, 'Exact headers', 'Exact headers keys and values');
+            start();
+        }
+    });
+
+    $.mockjax.clear();
+});
+asyncTest('Exact multiple headers keys and values', function() {
+    $.mockjax({
+        url: '/exact/string',
+        requestHeaders: {
+            Authorization: "12345",
+            MyHeader: "hello"
+        },
+        responseText: 'Exact multiple headers'
+    });
+
+    $.ajax({
+        url: '/exact/string',
+        error: noErrorCallbackExpected,
+        headers: {
+            Authorization: "12345",
+            MyHeader: "hello"
+        },
+        complete: function(xhr) {
+            equal(xhr.responseText, 'Exact multiple headers', 'Exact headers keys and values');
+            start();
+        }
+    });
+
+    $.mockjax.clear();
+});
+
 module('URL Matching');
 asyncTest('Exact string', function() {
 	$.mockjax({


### PR DESCRIPTION
This pull requests adds a new property you can define in the mockjax options object called ```requestHeaders```. 
```requestHeaders``` is just an object with key, value pairs defining which headers are needed by the request to be validated.

here is an example which will match all the requests to /me only if the request includes an header called ```Authorization``` with value ```"Bearer vsdfjsdf+adfvadfv="```
```
$.mockjax({
    url: "/me",
    requestHeaders: {
        Authorization: "Bearer vsdfjsdf+adfvadfv="
    },
    responseText: "YEAH!"
}
```