### PR TITLE
Automatically run tests against multiple jQuery versions

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,22 +2,6 @@
 module.exports = function(grunt) {
 	'use strict';
 
-	var jQueryVersions = [
-		'1.5.2',
-		'1.6.4',
-		'1.7.2',
-		'1.8.3',
-		'1.9.1',
-		'1.10.2',
-		'1.11.1',
-		'2.0.3',
-		'2.1.1',
-		'git',
-	];
-		/*
-		<a href="?jquery=1.9.1">jQuery 1.9.1</a>
-		 */
-
 	// Project configuration.
 	grunt.initConfig({
 		// Metadata.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,6 @@
 /*global module:false*/
 module.exports = function(grunt) {
+	'use strict';
 
     // Project configuration.
     grunt.initConfig({

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,11 +2,27 @@
 module.exports = function(grunt) {
 	'use strict';
 
+	var jQueryVersions = [
+		'1.5.2',
+		'1.6.4',
+		'1.7.2',
+		'1.8.3',
+		'1.9.1',
+		'1.10.2',
+		'1.11.1',
+		'2.0.3',
+		'2.1.1',
+		'git',
+	];
+		/*
+		<a href="?jquery=1.9.1">jQuery 1.9.1</a>
+		 */
+
 	// Project configuration.
 	grunt.initConfig({
 		// Metadata.
 		pkg: grunt.file.readJSON('package.json'),
-		
+
 		banner: '/*! MockJax - jQuery Plugin to Mock Ajax requests \n'+
 			'* <%= pkg.title || pkg.name %>\n' +
 			'* \n' +
@@ -48,8 +64,33 @@ module.exports = function(grunt) {
 				src: 'src/**/*.js'
 			}
 		},
-		qunit: {
-			all: ['test/index.html']
+		qunit: { all: [] },  // NOTE: these tests are all run by the `test` task below to run against each jQuery version supported
+		test: {
+			jQueryVersions: [
+				'1.5.2',
+				'1.6.4',
+				'1.7.2',
+				'1.8.3',
+				'1.9.1',
+				'1.10.2',
+				'1.11.1',
+				'2.0.3',
+				'2.1.1',
+				'git'
+			],
+			latestInBranch: {
+				jQueryVersions: [
+					'1.11.1',
+					'2.1.1'
+				]
+			},
+			oldestAndLatest: {
+				jQueryVersions: [
+					'1.5.2',
+					'1.11.1',
+					'2.1.1'
+				]
+			}
 		},
 		watch: {
 			gruntfile: {
@@ -67,5 +108,20 @@ module.exports = function(grunt) {
 
 	grunt.registerTask('build', ['concat', 'uglify']);
 	grunt.registerTask('default', ['jshint', 'qunit', 'build']);
+
+
+	grunt.registerTask('test', 'Executes QUnit tests with all supported jQuery versions', function() {
+		var i, l,
+			versionUrls = [],
+			versions = grunt.config.get('test' + ((arguments[0]) ? '.'+arguments[0] : '') + '.jQueryVersions') || [];
+
+		for (i=0, l=versions.length; i<l; ++i) {
+			grunt.log.writeln('Adding jQuery version to test: ' + versions[i]);
+			versionUrls.push('test/index.html?jquery=' + versions[i]);
+		}
+
+		grunt.config.set('qunit.options.urls', versionUrls);
+		grunt.task.run('qunit');
+	});
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,69 +2,70 @@
 module.exports = function(grunt) {
 	'use strict';
 
-    // Project configuration.
-    grunt.initConfig({
-        // Metadata.
-        pkg: grunt.file.readJSON('package.json'),
-        banner: '/*! MockJax - jQuery Plugin to Mock Ajax requests \n'+
-            '* <%= pkg.title || pkg.name %>\n' +
-            '* \n' +
-            '* Version: <%= pkg.version %> \n' +
-            '* Released: <%= grunt.template.today("yyyy-mm-dd") %> \n' +
-            '* Home: <%= pkg.homepage ? "* " + pkg.homepage + "\\n" : "" %>' +
-            '* Copyright (c) <%= grunt.template.today("yyyy") %> Jordan Kasper, formerly appendTo;\n' +
-            '* NOTE: This repository was taken over by Jordan Kasper (@jakerella) October, 2014\n' +
-            '* \n' +
-            '* Dual licensed under the MIT or GPL licenses.\n' +
-            '* http://opensource.org/licenses/MIT OR http://www.gnu.org/licenses/gpl-2.0.html\n' +
-            '*/\n',
-            
-        // Task configuration.
-        concat: {
-            options: {
-                banner: '<%= banner %>',
-                stripBanners: true
-            },
-            dist: {
-                src: ['src/<%= pkg.name %>.js'],
-                dest: 'dist/<%= pkg.name %>.js'
-            }
-        },
-        uglify: {
-            options: {
-                banner: '<%= banner %>'
-            },
-            dist: {
-                src: '<%= concat.dist.dest %>',
-                dest: 'dist/<%= pkg.name %>.min.js'
-            }
-        },
-        jshint: {
-            options: {
-                jshintrc: true
-            },
-            all: {
-                src: 'src/**/*.js'
-            }
-        },
-        qunit: {
-            all: ['test/index.html']
-        },
-        watch: {
-            gruntfile: {
-                files: '<%= jshint.gruntfile.src %>',
-                tasks: ['jshint:gruntfile']
-            },
-            lib_test: {
-                files: '<%= jshint.lib_test.src %>',
-                tasks: ['jshint:lib_test', 'nodeunit']
-            }
-        }
-    });
+	// Project configuration.
+	grunt.initConfig({
+		// Metadata.
+		pkg: grunt.file.readJSON('package.json'),
+		
+		banner: '/*! MockJax - jQuery Plugin to Mock Ajax requests \n'+
+			'* <%= pkg.title || pkg.name %>\n' +
+			'* \n' +
+			'* Version: <%= pkg.version %> \n' +
+			'* Released: <%= grunt.template.today("yyyy-mm-dd") %> \n' +
+			'* Home: <%= pkg.homepage ? "* " + pkg.homepage + "\\n" : "" %>' +
+			'* Copyright (c) <%= grunt.template.today("yyyy") %> Jordan Kasper, formerly appendTo;\n' +
+			'* NOTE: This repository was taken over by Jordan Kasper (@jakerella) October, 2014\n' +
+			'* \n' +
+			'* Dual licensed under the MIT or GPL licenses.\n' +
+			'* http://opensource.org/licenses/MIT OR http://www.gnu.org/licenses/gpl-2.0.html\n' +
+			'*/\n',
+			
+		// Task configuration.
+		concat: {
+			options: {
+				banner: '<%= banner %>',
+				stripBanners: true
+			},
+			dist: {
+				src: ['src/<%= pkg.name %>.js'],
+				dest: 'dist/<%= pkg.name %>.js'
+			}
+		},
+		uglify: {
+			options: {
+				banner: '<%= banner %>'
+			},
+			dist: {
+				src: '<%= concat.dist.dest %>',
+				dest: 'dist/<%= pkg.name %>.min.js'
+			}
+		},
+		jshint: {
+			options: {
+				jshintrc: true
+			},
+			all: {
+				src: 'src/**/*.js'
+			}
+		},
+		qunit: {
+			all: ['test/index.html']
+		},
+		watch: {
+			gruntfile: {
+				files: '<%= jshint.gruntfile.src %>',
+				tasks: ['jshint:gruntfile']
+			},
+			lib_test: {
+				files: '<%= jshint.lib_test.src %>',
+				tasks: ['jshint:lib_test', 'nodeunit']
+			}
+		}
+	});
 
-    require('load-grunt-tasks')(grunt);
+	require('load-grunt-tasks')(grunt);
 
-    grunt.registerTask('build', ['concat', 'uglify']);
-    grunt.registerTask('default', ['jshint', 'qunit', 'build']);
+	grunt.registerTask('build', ['concat', 'uglify']);
+	grunt.registerTask('default', ['jshint', 'qunit', 'build']);
 
 };

--- a/test/index.html
+++ b/test/index.html
@@ -12,7 +12,7 @@
       </head>
     <body>
         <h1 id="qunit-header">
-            MockJax
+            Mockjax
             <a href="?jquery=1.5.2">jQuery 1.5.2</a>
             <a href="?jquery=1.6.4">jQuery 1.6.4</a>
             <a href="?jquery=1.7.2">jQuery 1.7.2</a>
@@ -23,6 +23,7 @@
             <a href="?jquery=2.0.3">jQuery 2.0.3</a>
             <a href="?jquery=2.1.1">jQuery 2.1.1</a>
             <a href="?jquery=git">jQuery Latest (git)</a>
+            <button class="runall" disabled="disabled">Run All Versions</button>
         </h1>
         <h2 id="qunit-banner"></h2>
         <h2 id="qunit-userAgent"></h2>

--- a/test/index.html
+++ b/test/index.html
@@ -13,8 +13,6 @@
     <body>
         <h1 id="qunit-header">
             MockJax
-            <a href="?jquery=1.3.2">jQuery 1.3.2</a>
-            <a href="?jquery=1.4.4">jQuery 1.4.4</a>
             <a href="?jquery=1.5.2">jQuery 1.5.2</a>
             <a href="?jquery=1.6.4">jQuery 1.6.4</a>
             <a href="?jquery=1.7.2">jQuery 1.7.2</a>

--- a/test/jquery.js
+++ b/test/jquery.js
@@ -1,25 +1,93 @@
 (function() {
+	"use strict";
 
-var parts = document.location.search.slice( 1 ).split( "&" ),
-	length = parts.length,
-	i = 0,
-	current,
-	version = "2.1.1",
-	file = "http://code.jquery.com/jquery-git.js";
+	var parts = document.location.search.slice( 1 ).split( "&" ),
+		length = parts.length,
+		i = 0,
+		current,
+		QUnitDone = false,
+		QUnitErrors = false,
+		currIndex = document.location.search.match(/v=([0-9]+)/),
+		nextIndex = (currIndex && Number(currIndex[1]) || 0) + 1, // +1 because QUnit makes the h1 text a link
+		version = "1.5.2",
+		file = "http://code.jquery.com/jquery-git.js";
 
-for ( ; i < length; i++ ) {
-	current = parts[ i ].split( "=" );
-	if ( current[ 0 ] === "jquery" ) {
-		version = current[ 1 ];
-		break;
+	for ( ; i < length; i++ ) {
+		current = parts[ i ].split( "=" );
+		if ( current[ 0 ] === "jquery" ) {
+			version = current[ 1 ];
+			break;
+		}
 	}
-}
 
-if (version != "git") {
-	file = "../lib/jquery-" + version + ".js";
-}
+	if (version != "git") {
+		file = "../lib/jquery-" + version + ".js";
+	}
 
 
-document.write( "<script src='" + file + "'></script>" );
+	document.write( "<script id='jquery' src='" + file + "'></script>" );
+
+
+	// Track when QUnit finishes so we can redirect if necessary
+	QUnit.done(function(details) {
+		QUnitDone = true;
+		QUnitErrors = !!details.failed;
+	});
+
+
+	// Set up the "run all" button once jQuery is loaded
+	document.getElementById("jquery").onload = function() {
+		$(document).ready(function() {
+			// Sigh... QUnit "rebuilds" the header, so we have to wait for that before
+			// attaching our click event, otherwise we lose the handler in the rebuild
+			setTimeout(function() {
+				var btn = $(".runall");
+
+				if (currIndex) {
+					// We're already in a run...
+					btn.attr("disabled", "disabled");
+					setupNextRedirect();
+
+				} else {
+					// Set up a new run...
+					btn.removeAttr("disabled").click(function(e) {
+						e.preventDefault();
+						setupNextRedirect();
+					});
+				}
+			}, 1000);
+		});
+	};
+
+	function getNextLink() {
+		var nextLink = null,
+			nextLinkNode = $("#qunit-header a:eq(" + nextIndex + ")");
+		
+		if (nextLinkNode && nextLinkNode.length) {
+			nextLink = nextLinkNode.attr("href") + "&v=" + nextIndex;
+		}
+		return nextLink;
+	}
+
+	function setupNextRedirect() {
+		var nextLink = getNextLink();
+
+		if (nextLink) {
+			if (QUnitDone && !QUnitErrors) {
+				// QUnit already finished, so we'll redirect
+				document.location.replace(nextLink);
+
+			} else if (!QUnitDone) {
+				QUnit.done(function(details) {
+					if (!details.failed) {
+						// we only redirect if the last test run succeeded
+						setTimeout(function() {
+							document.location.replace(nextLink);
+						}, 1000);
+					}
+				});
+			}
+		}
+	}
 
 })();

--- a/test/test.js
+++ b/test/test.js
@@ -41,6 +41,7 @@ function normalizeSemVer(v) {
 
 // Speed up our tests
 $.mockjaxSettings.responseTime = 0;
+$.mockjaxSettings.logging = false;
 var defaultSettings = $.extend({}, $.mockjaxSettings);
 
 QUnit.testDone(function() {


### PR DESCRIPTION
This PR resolves #176 as well as adding some additional functionality. The basic idea is to make running tests against multiple jQuery versions easier. To do so, I've added two integrations: one for grunt and one for QUnit through a visual browser.

IN GRUNT we can now run `grunt test` and all tests will run against all supported versions of jQuery as documented in the Gruntfile task config. Additionally there are smaller subsets to run against such as `grunt test:oldestAndLatest` to test against our oldest and latest supported versions.

IN A BROWSER there is now a button in the header to run all tests for the list versions of jQuery in that header. Basically it waits for the `QUnit.done()` callback then redirects the user to the next link in the page based on their index in the header. This is finicky because we already dynamically load the jquery version, so we have to wait for that, and QUnit rebuilds that header (ugh) so we have to delay our binding to the button. I have it working in most cases, and it will stop the auto-redirection if any test fails.

Opinions welcome!

(Tagging @dcneiner or @jcreamer898 for some verification before merging.)