### PR TITLE
Remove duplicate `repositories` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,5 @@
          "type": "GPLv2",
          "url": "http://www.gnu.org/licenses/gpl-2.0.html"
      }
-  ],
-  "repositories": [
-     {
-         "type": "git",
-         "url": "https://github.com/jakerella/jquery-mockjax.git"
-     }
   ]
 }


### PR DESCRIPTION
`repositories` is not needed and causes a warning in npm. Fixes issue #202.
