### PR TITLE
Remove duplicate `repositories` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,12 +44,6 @@
       "url": "http://www.gnu.org/licenses/gpl-2.0.html"
     }
   ],
-  "repositories": [
-    {
-      "type": "git",
-      "url": "http://github.com/jakerella/jquery-mockjax.git"
-    }
-  ],
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-qunit": "^0.5.2",


### PR DESCRIPTION
Repositories is not needed and causes a warning in npm. Fixes issue #202.

Second pull request for v2 : as asked in PR #215
