### PR TITLE
Add wrapper for AMDJS, CommonJS and browser modules

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -13,7 +13,20 @@
  * Dual licensed under the MIT or GPL licenses.
  * http://opensource.org/licenses/MIT OR http://www.gnu.org/licenses/gpl-2.0.html
  */
-(function($) {
+(function(root, factory) {
+	// AMDJS module definition
+	if ( typeof define === 'function' && define.amd ) {
+		define(['jquery'], function($) {
+			return factory($);
+		});
+	// CommonJS module definition
+	} else if ( typeof exports === 'object') {
+		module.exports = factory(require('jquery'));
+	// Global jQuery in web browsers
+	} else {
+		return factory(root.jQuery || root.$);
+	}
+}(this, function($) {
 	var _ajax = $.ajax,
 		mockHandlers = [],
 		mockedAjaxCalls = [],
@@ -689,4 +702,7 @@
 	$.mockjax.unmockedAjaxCalls = function() {
 		return unmockedAjaxCalls;
 	};
-})(jQuery);
+
+	return $.mockjax;
+
+}));


### PR DESCRIPTION
Adds wrapping factory function recognizing the three environments and plugging the mockjax into jQuery accordingly.

Includes just this change an no other refactoring.

Uses the [universal module pattern](https://github.com/umdjs/umd) and the name 'jquery' for the jQuery module dependency.