### PR TITLE
fix: remove undefined `head` variable

### DIFF
--- a/jquery.mockjax.js
+++ b/jquery.mockjax.js
@@ -9,7 +9,7 @@
  *
  * Copyright (c) 2014 appendTo, Jordan Kasper
  * NOTE: This repository was taken over by Jordan Kasper (@jakerella) October, 2014
- * 
+ *
  * Dual licensed under the MIT or GPL licenses.
  * http://opensource.org/licenses/MIT OR http://www.gnu.org/licenses/gpl-2.0.html
  */
@@ -416,9 +416,6 @@
 				delete window[ jsonp ];
 			} catch(e) {}
 
-			if ( head ) {
-				head.removeChild( script );
-			}
 		};
 	}
 


### PR DESCRIPTION
This undefined variable causes JSONP requests to fail.