### PR TITLE
Removed the previously deprecated mockjaxClear method

### DIFF
--- a/src/jquery.mockjax.js
+++ b/src/jquery.mockjax.js
@@ -701,15 +701,6 @@
 		mockedAjaxCalls = [];
 		unmockedAjaxCalls = [];
 	};
-	// support older, deprecated version
-	$.mockjaxClear = function(i) {
-		if (window.console && window.console.warn) {
-            /* jshint maxlen:180 */
-			window.console.warn( 'DEPRECATED: The $.mockjaxClear() method has been deprecated in 1.6.0. Please use $.mockjax.clear() as the older function will be removed soon!' );
-            /* jshint maxlen:140 */
-		}
-		$.mockjax.clear(i);
-	};
 	$.mockjax.handler = function(i) {
 		if ( arguments.length === 1 ) {
 			return mockHandlers[i];

--- a/test/test.js
+++ b/test/test.js
@@ -345,16 +345,6 @@ asyncTest('Clearing mockjax removes all handlers', function() {
 	});
 });
 
-test('Old version of clearing mock handlers works', function() {
-	$.mockjax({
-		url: '/api/example/1'
-	});
-
-	$.mockjaxClear();
-
-	equal($.mockjax.handler(0), undefined, 'There are no mock handlers');
-});
-
 
 asyncTest('Get mocked ajax calls - GET', function() {
 	$.mockjax({


### PR DESCRIPTION
This PR removes the previously deprecated `$.mockjaxClear()` method in favor of the `$.mockjax.clear()` method. See issue #175 for that implementation (PR).