### PR TITLE
jQuery is a dependency but is not reflected in bower.json.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "version": "2.0.0-beta",
   "main": ["dist/jquery.mockjax.js"],
   "dependencies": {
-    "jquery": "*"
+    "jquery": "~2.1.3"
   },
   "ignore": [
     ".editorconfig",

--- a/bower.json
+++ b/bower.json
@@ -2,6 +2,9 @@
   "name": "jquery-mockjax",
   "version": "2.0.0-beta",
   "main": ["dist/jquery.mockjax.js"],
+  "dependencies": {
+    "jquery": "*"
+  },
   "ignore": [
     ".editorconfig",
     ".gitignore",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
       "url": "http://www.gnu.org/licenses/gpl-2.0.html"
     }
   ],
+  "dependencies": {
+    "jquery": "^2.1.3"
+  },
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-concat": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "grunt-contrib-uglify": "^0.6.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-mocha-test": "^0.12.7",
-    "jquery": "^2.1.3",
     "jsdom": "^4.2.0",
     "load-grunt-tasks": "^0.6.0",
     "mocha": "^2.2.4",


### PR DESCRIPTION
Without a dependency declaration, mockjax can wind up getting put into a large lib.js file first (depending on your build tools), which will cause an error because neither jQuery nor $ have been defined yet.