### PR TITLE
make it possible to clear mocks with a given url

### DIFF
--- a/src/jquery.mockjax.js
+++ b/src/jquery.mockjax.js
@@ -673,9 +673,11 @@
 	 * @returns {Array}
 	 */
 	function clearByUrl(url) {
-		var results = [];
-		for (var i=0, len=mockHandlers.length; i<len; i++) {
-			var handler = mockHandlers[i];
+		var i, len,
+			handler,
+			results = [];
+		for (i=0, len=mockHandlers.length; i<len; i++) {
+			handler = mockHandlers[i];
 			if (handler.url !== url) {
 				results.push(handler);
 			}

--- a/src/jquery.mockjax.js
+++ b/src/jquery.mockjax.js
@@ -675,10 +675,13 @@
 	function clearByUrl(url) {
 		var i, len,
 			handler,
-			results = [];
+			results = [],
+			match=url instanceof RegExp ?
+				function(testUrl) { return url.test(testUrl); } :
+				function(testUrl) { return url === testUrl; };
 		for (i=0, len=mockHandlers.length; i<len; i++) {
 			handler = mockHandlers[i];
-			if (handler.url !== url) {
+			if (!match(handler.url)) {
 				results.push(handler);
 			}
 		}
@@ -746,7 +749,7 @@
 		return i;
 	};
 	$.mockjax.clear = function(i) {
-		if ( typeof i === 'string' ) {
+		if ( typeof i === 'string' || i instanceof RegExp) {
 			mockHandlers = clearByUrl(i);
 		} else if ( i || i === 0 ) {
 			mockHandlers[i] = null;

--- a/src/jquery.mockjax.js
+++ b/src/jquery.mockjax.js
@@ -667,6 +667,22 @@
 		origSettings.urlParams = paramValues;
 	}
 
+	/**
+	 * Clears handlers that mock given url
+	 * @param url
+	 * @returns {Array}
+	 */
+	function clearByUrl(url) {
+		var results = [];
+		for (var i=0, len=mockHandlers.length; i<len; i++) {
+			var handler = mockHandlers[i];
+			if (handler.url !== url) {
+				results.push(handler);
+			}
+		}
+		return results;
+	}
+
 
 	// Public
 
@@ -728,7 +744,9 @@
 		return i;
 	};
 	$.mockjax.clear = function(i) {
-		if ( i || i === 0 ) {
+		if ( typeof i === 'string' ) {
+			mockHandlers = clearByUrl(i);
+		} else if ( i || i === 0 ) {
 			mockHandlers[i] = null;
 		} else {
 			mockHandlers = [];

--- a/test/test.js
+++ b/test/test.js
@@ -333,6 +333,109 @@ test('Remove mockjax definition by url', function() {
 	});
 });
 
+test('Remove mockjax definition by url (no default handler)', function() {
+	$.mockjax({
+		url: '/test',
+		contentType: 'text/plain',
+		responseText: 'test'
+	});
+
+	stop();
+	$.ajax({
+		url: '/test',
+		success: function(text) {
+			equal(text, 'test', 'Test handler responded');
+		},
+		error: noErrorCallbackExpected,
+		complete: function() {
+			$.mockjax.clear('/test');
+
+			// Reissue the request expecting the error
+			$.ajax({
+				url: '/test',
+				success: function() {
+					ok(false, 'The mock was not cleared by url');
+				},
+				error: function(xhr) {
+					// Test against 0, might want to look at this more in depth
+					ok(404 === xhr.status || 0 === xhr.status, 'The mock was cleared by url');
+					start();
+				}
+			});
+		}
+	});
+});
+
+test('Attempt to clear a non-existent but similar url', function() {
+	$.mockjax({
+		url: '/test',
+		contentType: 'text/plain',
+		responseText: 'test'
+	});
+
+	$.mockjax({
+		url: '*',
+		contentType: 'text/plain',
+		responseText: 'default'
+	});
+
+	stop();
+	$.ajax({
+		url: '/test',
+		success: function(text) {
+			equal(text, 'test', 'Test handler responded');
+		},
+		error: noErrorCallbackExpected,
+		complete: function() {
+			$.mockjax.clear('/tes');
+
+			$.ajax({
+				url: '/test',
+				success: function(text) {
+					equal(text, 'test', 'Test handler responded');
+					start();
+				},
+				error: noErrorCallbackExpected
+			});
+		}
+	});
+});
+
+test('Remove mockjax definition, but not a subpath', function() {
+	$.mockjax({
+		url: '/test',
+		contentType: 'text/plain',
+		responseText: 'test'
+	});
+
+	$.mockjax({
+		url: '/test/foo',
+		contentType: 'text/plain',
+		responseText: 'foo'
+	});
+
+	stop();
+	$.ajax({
+		url: '/test',
+		success: function(text) {
+			equal(text, 'test', 'Test handler responded');
+		},
+		error: noErrorCallbackExpected,
+		complete: function() {
+			$.mockjax.clear('/test');
+
+			$.ajax({
+				url: '/test/foo',
+				success: function(text) {
+					equal(text, 'foo', 'Test handler responded');
+					start();
+				},
+				error: noErrorCallbackExpected
+			});
+		}
+	});
+});
+
 asyncTest('Clearing mockjax removes all handlers', function() {
 	$.mockjax({
 		url: '/api/example/1',

--- a/test/test.js
+++ b/test/test.js
@@ -294,6 +294,45 @@ test('Remove mockjax definition by id', function() {
 	});
 });
 
+test('Remove mockjax definition by url', function() {
+	$.mockjax({
+		url: '/test',
+		contentType: 'text/plain',
+		responseText: 'test'
+	});
+
+	$.mockjax({
+		url: '*',
+		contentType: 'text/plain',
+		responseText: 'default'
+	});
+
+	stop();
+	$.ajax({
+		url: '/test',
+		success: function(text) {
+			equal(text, 'test', 'Test handler responded');
+		},
+		error: noErrorCallbackExpected,
+		complete: function() {
+			$.mockjax.clear('/test');
+
+			// Reissue the request expecting the default handler
+			$.ajax({
+				url: '/test',
+				success: function(text) {
+					equal(text, 'default', 'Default handler responded');
+				},
+				error: noErrorCallbackExpected,
+				complete: function(xhr) {
+					equal(xhr.responseText, 'default', 'Default handler responded');
+					start();
+				}
+			});
+		}
+	});
+});
+
 asyncTest('Clearing mockjax removes all handlers', function() {
 	$.mockjax({
 		url: '/api/example/1',

--- a/test/test.js
+++ b/test/test.js
@@ -436,6 +436,96 @@ test('Remove mockjax definition, but not a subpath', function() {
 	});
 });
 
+test('Remove mockjax definition by RegExp', function() {
+	$.mockjax({
+		url: '/test',
+		contentType: 'text/plain',
+		responseText: 'test'
+	});
+
+	$.mockjax({
+		url: '*',
+		contentType: 'text/plain',
+		responseText: 'default'
+	});
+
+	stop();
+	$.ajax({
+		url: '/test',
+		success: function(text) {
+			equal(text, 'test', 'Test handler responded');
+		},
+		error: noErrorCallbackExpected,
+		complete: function() {
+			$.mockjax.clear(/test/);
+
+			// Reissue the request expecting the default handler
+			$.ajax({
+				url: '/test',
+				success: function(text) {
+					equal(text, 'default', 'Default handler responded');
+				},
+				error: noErrorCallbackExpected,
+				complete: function(xhr) {
+					equal(xhr.responseText, 'default', 'Default handler responded');
+					start();
+				}
+			});
+		}
+	});
+});
+
+test('Remove several mockjax definition by RegExp', function() {
+	$.mockjax({
+		url: '/test',
+		contentType: 'text/plain',
+		responseText: 'test'
+	});
+
+	$.mockjax({
+		url: '/test1',
+		contentType: 'text/plain',
+		responseText: 'test'
+	});
+
+	$.mockjax({
+		url: '/test/foo',
+		contentType: 'text/plain',
+		responseText: 'test'
+	});
+
+	$.mockjax({
+		url: '*',
+		contentType: 'text/plain',
+		responseText: 'default'
+	});
+
+	stop();
+	$.ajax({
+		url: '/test',
+		success: function(text) {
+			equal(text, 'test', 'Test handler responded');
+		},
+		error: noErrorCallbackExpected,
+		complete: function() {
+			$.mockjax.clear(/test/);
+
+			// Reissue the request expecting the default handler
+			$.ajax({
+				url: '/test',
+				success: function(text) {
+					equal(text, 'default', 'Default handler responded');
+				},
+				error: noErrorCallbackExpected,
+				complete: function(xhr) {
+					equal(xhr.responseText, 'default', 'Default handler responded');
+					start();
+				}
+			});
+		}
+	});
+});
+
 asyncTest('Clearing mockjax removes all handlers', function() {
 	$.mockjax({
 		url: '/api/example/1',


### PR DESCRIPTION
In my test environment I use method chaining to write tests:
```javascript
test.open()
    .mock({ url: '/something' })
    .mock({ url: '/another' })
    .assert(...)
```

Currently if I want to re-mock one of the mocks, I have to clear all of them and mock again:
```javascript
test.open()
    .mock({ url: '/something', responseText: '1' })
    .mock({ url: '/another' })
    .assert(...)
    .clearMocks()
    .mock({ url: '/something', responseText: '2' })
    .mock({ url: '/another' })
```

It would be really nice if I could remove only mocks with a specific url:
```javascript
test.open()
    .mock({ url: '/something', responseText: '1' })
    .mock({ url: '/another' })
    .assert(...)
    .clearMock('/something')
    .mock({ url: '/something', responseText: '2' })
```