### PR TITLE
Update bower.json to allow ES6 importing

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "jquery-mockjax",
-  "main": ["dist/jquery.mockjax.js"],
+  "main": "dist/jquery.mockjax.js",
   "dependencies": {
     "jquery": ">=1.5.0"
   },


### PR DESCRIPTION
By updating the `main` key, of `bower.json`, ES6 can import mockjax with just the following code:

```
import 'jquery-mockjax';
```