### PR TITLE
include support for responseTime to deferred jsonp requests

### DIFF
--- a/src/jquery.mockjax.js
+++ b/src/jquery.mockjax.js
@@ -501,15 +501,15 @@
 		setTimeout(function() {
 			jsonpSuccess( requestSettings, callbackContext, mockHandler );
 			jsonpComplete( requestSettings, callbackContext );
+
+            if ( newMock ) {
+                try {
+                    json = $.parseJSON( mockHandler.responseText );
+                } catch (err) { /* just checking... */ }
+
+                newMock.resolveWith( callbackContext, [json || mockHandler.responseText] );
+            }
 		}, parseResponseTimeOpt( mockHandler.responseTime ));
-
-		if ( newMock ) {
-			try {
-				json = $.parseJSON( mockHandler.responseText );
-			} catch (err) { /* just checking... */ }
-
-			newMock.resolveWith( callbackContext, [json || mockHandler.responseText] );
-		}
 	}
 
 

--- a/test/test-connection.js
+++ b/test/test-connection.js
@@ -119,6 +119,26 @@
 		}, 30);
 	});
 
+	t('Response time with jsonp deferred response', function(assert) {
+		var done = assert.async();
+		var executed = false, ts = new Date();
+
+		$.ajax({
+			url: 'http://foobar.com/jsonp-delay?callback=?',
+			dataType: 'jsonp'
+		}).done(function() {
+            var delay = ((new Date()) - ts);
+            assert.ok( delay >= 150, 'Correct delay simulation (' + delay + ')' );
+            assert.ok( executed, 'Callback execution order correct');
+            done();
+		});
+
+		setTimeout(function() {
+			assert.ok( executed === false, 'No premature callback execution');
+			executed = true;
+		}, 30);
+	});
+
 	t('Response time with min and max values', function (assert) {
 		var done = assert.async();
 		

--- a/test/test-data-types.js
+++ b/test/test-data-types.js
@@ -176,9 +176,8 @@
 
 		$.when(req1, req2, req3).done(function() {
 			assert.ok(true, 'Successfully grouped deferred responses');
+			done();
 		});
-
-		done();
 	});
 	
 	t('Response returns parsed XML', function(assert) {


### PR DESCRIPTION
responseTime configuration does not work for deferred-style jsonp ajax requests. This PR fixes it.