### PR TITLE
deps(jquery): upgrade deps jquery@3

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     }
   ],
   "dependencies": {
-    "jquery": "^2.1.3"
+    "jquery": ">=1.5.2"
   },
   "devDependencies": {
     "browserify": "^13.1.0",


### PR DESCRIPTION
I'm use jquery@3 and jquery-mockjax@2.2.0, When I use webpack build jquery and jquery-mockjax, jQuery object has no mockjax method, because jquery-mockjax deps jquery@2

Can you upgrade deps jquery@3 ?

Thank you.