### PR TITLE
Fix syntax error in sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,25 +274,25 @@ The data option may be a custom matching function returning `true` of `false`
 whether the data is expected or not:
 
 ```javascript
-$.mockjax([
+$.mockjax({
   url: "/rest",
   data: function( data ) {
     return deepEqual( data, expected );
   }
-]);
+});
 ```
 
 The data function is a recommended place for assertions. Return `true` and let
 a testing framework of choice do the rest:
 
 ```javascript
-$.mockjax([
+$.mockjax({
   url: "/rest",
   data: function ( json ) {
     assert.deepEqual( JSON.parse(json), expected ); // QUnit example.
     return true;
   }
-]);
+});
 ```
 
 To capture URL parameters, use a capturing regular expression for the


### PR DESCRIPTION
The sample code uses `[` instead of `{` in some places.