### PR TITLE
Fix bug 314: setting null namespace on single mock handler

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to Mockjax #
 
-First of all, thank you for helping make Mockjax the best plugin it can be! We truly 
-appreciate the support. Before you submit that Pull Request, please be sure to 
+First of all, thank you for helping make Mockjax the best plugin it can be! We truly
+appreciate the support. Before you submit that Pull Request, please be sure to
 follow these guidelines.
 
 ## Key Points
@@ -15,48 +15,48 @@ follow these guidelines.
 
 ## Accurately describe your code submission ##
 
-Be sure to identify everything that is within your pull request in the description. 
-If you have code that fixes a bug and also cleans up some documentation, please 
-specify both! Additionally, if your PR fixes or resolves a specific Github issue 
+Be sure to identify everything that is within your pull request in the description.
+If you have code that fixes a bug and also cleans up some documentation, please
+specify both! Additionally, if your PR fixes or resolves a specific Github issue
 please reference it using the `#[id]` format so that the two can be linked!
 
 ### Commit messages ###
 
-Just as with the PR description, your commit messages should clearly identify what 
-was included in that commit. Keep them short and sweet so we can just scan the 
+Just as with the PR description, your commit messages should clearly identify what
+was included in that commit. Keep them short and sweet so we can just scan the
 titles of the commit and dig deeper if we need to.
 
 ### Smaller commits ###
 
-Along the same line, we would prefer to see different aspects of your PR in 
+Along the same line, we would prefer to see different aspects of your PR in
 separate commits versus one big commit. So if you are submitting a PR that fixes a
-bug, updates the documentation, and cleans up some whitespace, please place all 
-three of those things in **separate commits**! This allows us to roll back specific 
+bug, updates the documentation, and cleans up some whitespace, please place all
+three of those things in **separate commits**! This allows us to roll back specific
 work if need be without destroying the entire contribution.
 
 ## Try to keep the style consistent ##
 
 As much as possible we need to try to keep the coding style consistent within the
-plugin. That means using the same indentation style, quotes, spacing, etc. Please 
-try to keep your work in line with what is already in the library already, but 
-feel free to ping someone in the Github issues if you have any questions about 
+plugin. That means using the same indentation style, quotes, spacing, etc. Please
+try to keep your work in line with what is already in the library already, but
+feel free to ping someone in the Github issues if you have any questions about
 coding style generally.
 
 ## Add tests! ##
 
-We really need to see tests for any commit other than documentation. If you are 
-fixing a bug add a breaking test first, then the code that fixes that test. If you 
-are developing a new feature, add complete tests for the feature. That includes 
+We really need to see tests for any commit other than documentation. If you are
+fixing a bug add a breaking test first, then the code that fixes that test. If you
+are developing a new feature, add complete tests for the feature. That includes
 tests for success cases as well as failure cases!
 
-We use [QUnit](http://qunitjs.com/) as our testing tool of choice, so please write 
-them using that API. For now you can simply add them to the `/test/test.js` file. 
+We use [QUnit](http://qunitjs.com/) as our testing tool of choice, so please write
+them using that API. For now you can simply add them to the `/test/test.js` file.
 There are `module`s in there, so try to add the tests in a logical location.
 
 ### RUN THE TESTS ###
 
-Due to the need to load some of the proxy files asynchronously, you'll need to view 
-the test files over HTTP. You can do some initial testing with PhantomJS using the 
+Due to the need to load some of the proxy files asynchronously, you'll need to view
+the test files over HTTP. You can do some initial testing with PhantomJS using the
 Grunt task, but you should also test in (multiple) browsers!
 
 #### To run from Grunt...
@@ -68,6 +68,20 @@ Simply run:
 ```
 
 _Note that this will run all tests for all supported versions of jQuery!_
+
+Want to run just a subset of the tests? And maybe only a certain jQuery version? Try this:
+
+```shell
+~$ grunt test:version:3.2.1:core,namespace,bugs
+```
+
+The command above will run the "core", "namespace", and "bugs" test modules against jQuery version 3.2.1 _only_.
+
+You could also run something like the command below to test all supported jQuery versions, but only certain test modules:
+
+```shell
+~$ grunt test:all:core,namespace,bugs
+```
 
 #### To run in a browser...
 
@@ -92,46 +106,46 @@ PHP (5.4+):
 mockjax/$ php -S localhost:8080
 ```
 
-Then just visit http://localhost:8080/test/index.html in the browser! Once there, 
-be sure to **click through each of the jQuery versions in the header** to run the tests 
-against each version. (If you have trouble running in different versions, make sure 
+Then just visit http://localhost:8080/test/index.html in the browser! Once there,
+be sure to **click through each of the jQuery versions in the header** to run the tests
+against each version. (If you have trouble running in different versions, make sure
 you are viewing `/test/index.html` not just `/test/` .)
 
 ### Run your tests everywhere ###
 
-Lastly, we'd like you to run your tests on as many browsers as possible. Check the 
-main [README](README.md#browsers-tested) file for the browsers we support. If you 
-don't have access to one of those browsers, try running the tests using a virtual 
-machine or via a service like [BrowserStack](http://www.browserstack.com), 
+Lastly, we'd like you to run your tests on as many browsers as possible. Check the
+main [README](README.md#browsers-tested) file for the browsers we support. If you
+don't have access to one of those browsers, try running the tests using a virtual
+machine or via a service like [BrowserStack](http://www.browserstack.com),
 [Sauce Labs](https://saucelabs.com), or [Modern.IE](https://www.modern.ie).
 
 ## Be sure to generate a build!
 
-Running the default `grunt` task will only lint and test the files, it does not 
-produce a distribution as that isn't necessary most of the time. Instead, you 
-should generate a new set of "dist" files before submitting your PR. To do this, 
+Running the default `grunt` task will only lint and test the files, it does not
+produce a distribution as that isn't necessary most of the time. Instead, you
+should generate a new set of "dist" files before submitting your PR. To do this,
 just run `grunt build`
 
 ## Submit Your PR
 
-This is the last step! First, be sure you're merging with the correct branch! Version 
-2.0 of Mockjax will be the `master` branch very soon (hopefully we remember to update 
-this message), but if you're submitting a bug fix, it should be submitted to the `v1.x` 
+This is the last step! First, be sure you're merging with the correct branch! Version
+2.0 of Mockjax will be the `master` branch very soon (hopefully we remember to update
+this message), but if you're submitting a bug fix, it should be submitted to the `v1.x`
 branch as well as `master` (if the bug exists in both).
 
-You should also write a good PR message with information on why this feature or fix is 
-necesary or a good idea. For features, be sure to include information on _how to use_ 
+You should also write a good PR message with information on why this feature or fix is
+necesary or a good idea. For features, be sure to include information on _how to use_
 the feature; and for bugs, information on how to reproduce the bug is helpful!
 
 ## Publishing a Release
 
-Although individual contributors cannot publish a release, it's good to have 
-documentation on what goes into that in case anyone needs to take over the process. 
+Although individual contributors cannot publish a release, it's good to have
+documentation on what goes into that in case anyone needs to take over the process.
 Currently, @jakerella is the only one doing so.
 
 1. Create a branch for the release (usually with the proposed version number in the name)
 1. Ensure that all tests are passing in all supported browsers that you can (see below).
-1. Update the `CHANGELOG.md`, `package.json` version, and any other necessary files. 
+1. Update the `CHANGELOG.md`, `package.json` version, and any other necessary files.
 (Note that these can be in a commit, but put them in that new branch.)
 1. Make sure to generate fresh dist files if necessary and commit those.
 1. Submit a PR for the branch, this will initiate the Travis CI checks.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -170,21 +170,28 @@ module.exports = function(grunt) {
 		var i, l,
 			baseURL = 'http://localhost:' + PORT,
 			versionUrls = [],
+			testFiles = arguments[1] || null,
 			source = arguments[0] || 'all',
 			versions = grunt.config.get('test' + ('.' + source) + '.jQueryVersions') || [],
             file = grunt.config.get('test' + ('.' + source) + '.file') || 'index.html';
 
 		if (arguments[0] === 'version' && arguments[1]) {
 			versions = [arguments[1]];
+			testFiles = (arguments[2]) ? arguments[2] : null;
+		}
+
+		if (testFiles) {
+			testFiles = JSON.stringify(testFiles.split(/\,/));
 		}
 
 		for (i=0, l=versions.length; i<l; ++i) {
 			grunt.log.writeln('Adding jQuery version to test: ' + versions[i]);
+			grunt.log.writeln('Adding test modules: ' + testFiles);
 
 			if (arguments[0] === 'requirejs') {
-				versionUrls.push(baseURL + '/test/requirejs/' + file + '?jquery=' + versions[i]);
+				versionUrls.push(baseURL + '/test/requirejs/' + file + '?jquery=' + versions[i] + '&testFiles=' + testFiles);
 			} else {
-				versionUrls.push(baseURL + '/test/' + file + '?jquery=' + versions[i]);
+				versionUrls.push(baseURL + '/test/' + file + '?jquery=' + versions[i] + '&testFiles=' + testFiles);
 			}
 		}
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -174,6 +174,10 @@ module.exports = function(grunt) {
 			versions = grunt.config.get('test' + ('.' + source) + '.jQueryVersions') || [],
             file = grunt.config.get('test' + ('.' + source) + '.file') || 'index.html';
 
+		if (arguments[0] === 'version' && arguments[1]) {
+			versions = [arguments[1]];
+		}
+
 		for (i=0, l=versions.length; i<l; ++i) {
 			grunt.log.writeln('Adding jQuery version to test: ' + versions[i]);
 

--- a/src/jquery.mockjax.js
+++ b/src/jquery.mockjax.js
@@ -166,7 +166,7 @@
 			var effecitveUrl = handler.url;
 
 			// Apply namespace prefix to the mock handler's url.
-			var namespace = handler.namespace || $.mockjaxSettings.namespace;
+			var namespace = handler.namespace || (typeof(handler.namespace) === 'undefined' && $.mockjaxSettings.namespace);
 
 			if (!!namespace) {
 				var namespacedUrl = [

--- a/src/jquery.mockjax.js
+++ b/src/jquery.mockjax.js
@@ -163,20 +163,23 @@
 			}
 		} else {
 
+			var effecitveUrl = handler.url;
+
 			// Apply namespace prefix to the mock handler's url.
 			var namespace = handler.namespace || $.mockjaxSettings.namespace;
+
 			if (!!namespace) {
 				var namespacedUrl = [
 					namespace.replace(/(\/+)$/, ''),
 					handler.url.replace(/^(\/+)/, '')
 				].join('/');
-				handler.url = namespacedUrl;
+				effecitveUrl = namespacedUrl;
 			}
 
 			// Look for a simple wildcard '*' or a direct URL match
-			var star = handler.url.indexOf('*');
-			if (handler.url !== requestSettings.url && star === -1 ||
-					!new RegExp(handler.url.replace(/[-[\]{}()+?.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.+')).test(requestSettings.url)) {
+			var star = effecitveUrl.indexOf('*');
+			if (effecitveUrl !== requestSettings.url && star === -1 ||
+					!new RegExp(effecitveUrl.replace(/[-[\]{}()+?.,\\^$|#\s]/g, '\\$&').replace(/\*/g, '.+')).test(requestSettings.url)) {
 				return null;
 			}
 		}

--- a/test/add-tests.js
+++ b/test/add-tests.js
@@ -1,0 +1,36 @@
+
+(function() {
+    'use strict';
+
+    var i, l,
+        parts = document.location.search.match( /testFiles=([^&]+)/ ),
+        testFiles = [
+            'core',  // This will become: <script src='test-core.js'></script>
+            'data-match',
+            'data-types',
+            'header-match',
+            'url-match',
+            'headers',
+            'mock-clearing',
+            'retaining-ajax-calls',
+            'namespace',
+            'logging',
+            'connection',
+            'timeout',
+            'bugs'
+        ];
+
+    if ( parts && parts[1] ) {
+        try {
+            testFiles = JSON.parse( decodeURIComponent(parts[ 1 ]) ) || testFiles;
+        } catch(err) {
+            console.warn('\n WARNING: Unable to parse the test modules you wanted:', err);
+            testFiles = [];
+        }
+    }
+
+	for ( i=0, l = testFiles.length; i<l; i++ ) {
+		document.write( '<script src="test-' + testFiles[ i ] + '.js"></script>' );
+	}
+
+}());

--- a/test/index.html
+++ b/test/index.html
@@ -4,25 +4,14 @@
         <link rel='stylesheet' href='../lib/qunit.css' type='text/css' media='screen' />
         <script src='../lib/qunit.js'></script>
         <script src='../node_modules/sinon/pkg/sinon.js'></script>
-        <script src='jquery.js'></script>
+        <script src='jquery.js'></script>>
         <script src='../lib/json2.js'></script>
         <script src='../lib/semver.js'></script>
         <script src='../src/jquery.mockjax.js'></script>
 
         <script src='test-setup.js'></script>
-        <script src='test-core.js'></script>
-        <script src='test-data-match.js'></script>
-        <script src='test-data-types.js'></script>
-        <script src='test-header-match.js'></script>
-        <script src='test-url-match.js'></script>
-        <script src='test-headers.js'></script>
-        <script src='test-mock-clearing.js'></script>
-        <script src='test-retaining-ajax-calls.js'></script>
-        <script src='test-namespace.js'></script>
-        <script src='test-logging.js'></script>
-        <script src='test-connection.js'></script>
-        <script src='test-timeout.js'></script>
-        <script src='test-bugs.js'></script>
+
+        <script src='add-tests.js'></script>
 
         <title>MockJax Tests - </title>
       </head>

--- a/test/test-namespace.js
+++ b/test/test-namespace.js
@@ -1,12 +1,12 @@
 (function(qunit, $) {
 	'use strict';
-	
+
 	var t = qunit.test;
-	
+
 	/* -------------------- */
 	qunit.module('namespace');
 	/* -------------------- */
-	
+
 	t('url should be namespaced via global mockjax settings', function(assert) {
 		var done = assert.async();
 
@@ -202,6 +202,31 @@
 			complete: function(xhr) {
 				assert.equal(xhr.status, 200, 'Response was successful');
 				done();
+			}
+		});
+	});
+
+	t('should handle the same mock multiple times in a namespace', function(assert) {
+		var done = assert.async();
+
+		$.mockjaxSettings.namespace = '/api/v1';
+
+		$.mockjax({
+			url: 'one'
+		});
+
+		$.ajax({
+			url: '/api/v1/one',
+			error: qunit.noErrorCallbackExpected,
+			complete: function(xhr) {
+				assert.equal(xhr.status, 200, 'Response was successful');
+				$.ajax({
+					url: '/api/v1/one',
+					complete: function(xhr) {
+						assert.equal(xhr.status, 200, 'Response was successful');
+						done();
+					}
+				});
 			}
 		});
 	});

--- a/test/test-namespace.js
+++ b/test/test-namespace.js
@@ -222,11 +222,44 @@
 				assert.equal(xhr.status, 200, 'Response was successful');
 				$.ajax({
 					url: '/api/v1/one',
+					error: qunit.noErrorCallbackExpected,
 					complete: function(xhr) {
 						assert.equal(xhr.status, 200, 'Response was successful');
 						done();
 					}
 				});
+			}
+		});
+	});
+
+	t('should be able to declare no namespace on individual mock', function(assert) {
+
+		var done = assert.async();
+		$.mockjaxSettings.namespace = '/api/v1';
+
+		$.mockjax({
+			url: 'one'
+		});
+
+		$.mockjax({
+			url: '/two',
+			namespace: null
+		});
+
+		$.ajax({
+			url: '/api/v1/one',
+			error: qunit.noErrorCallbackExpected,
+			complete: function(xhr) {
+				assert.equal(xhr.status, 200, 'Response was successful');
+			}
+		});
+
+		$.ajax({
+			url: '/two',
+			error: qunit.noErrorCallbackExpected,
+			complete: function(xhr) {
+				assert.equal(xhr.status, 200, 'Response was successful');
+				done();
 			}
 		});
 	});


### PR DESCRIPTION
This PR fixes issue #314 where we try to set a `null` namespace for a single mock handler when we have an overall (global) mockjax namespace specified.