### PR TITLE
[WIP] Allow a list of possible return statuses (as a number or a string) which will get randomly picked from

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,9 +481,8 @@ $.mockjax({
 });
 ```
 
-The ability to provide a list of possible response statuses to randomly pick 
-from is also available by providing a double pipe-delimited list of possible 
-reponses.
+The ability to provide an array of possible response statuses (from which the response
+for a given request will be randomly picked from):
 
 ```javascript
 // Randomly fail

--- a/README.md
+++ b/README.md
@@ -481,6 +481,24 @@ $.mockjax({
 });
 ```
 
+The ability to provide a list of possible response statuses to randomly pick 
+from is also available by providing a double pipe-delimited list of possible 
+reponses.
+
+```javascript
+// Randomly fail
+$.mockjax({
+  url: "/restful/api",
+  status: '200||400||500'
+});
+
+// Randomly fail (with a preference towards success)
+$.mockjax({
+  url: "/restful/api",
+  status: '200||400||200||500||200'
+});
+```
+
 These forced error status codes will be handled just as if the server had
 returned the error: the `error` callback will get executed with the proper
 arguments.

--- a/README.md
+++ b/README.md
@@ -489,13 +489,13 @@ reponses.
 // Randomly fail
 $.mockjax({
   url: "/restful/api",
-  status: '200||400||500'
+  status: [200,400,500]
 });
 
 // Randomly fail (with a preference towards success)
 $.mockjax({
   url: "/restful/api",
-  status: '200||400||200||500||200'
+  status: [200,400,200,500,200]
 });
 ```
 

--- a/src/jquery.mockjax.js
+++ b/src/jquery.mockjax.js
@@ -277,10 +277,7 @@
 						}
 						
 						if ($.isArray(mockHandler.status)) {
-							var min = Math.ceil(0);
-							var max = Math.floor(mockHandler.status.length-1);
-							// get a random integer between two values, inclusive
-							var idxStatus = Math.floor(Math.random() * (max - min + 1)) + min;
+							var idxStatus = Math.floor(Math.random() * mockHandler.status.length)
 							this.status = mockHandler.status[idxStatus];							
 						} else if (typeof mockHandler.status === 'number' || typeof mockHandler.status === 'string') {
 							this.status = mockHandler.status;

--- a/src/jquery.mockjax.js
+++ b/src/jquery.mockjax.js
@@ -283,11 +283,11 @@
 							this.responseText = mockHandler.responseText;
 						}
 						
-						if( typeof mockHandler.status === 'number' || typeof mockHandler.status === 'string' ) {
-							// allow a double pipe-delimited list of strings or numbers, with the plugin randomly returning one of them
-							var arrStatus = (typeof mockHandler.status === 'string' ? mockHandler.status.replace(/\s+/g, '').split('||') : mockHandler.status.toString().split('||'));
-							var idxStatus = getRandomInteger(0,arrStatus.length-1);
-							this.status = arrStatus[idxStatus];
+						if ($.isArray(mockHandler.status)) {
+							var idxStatus = getRandomInteger(0,mockHandler.status.length-1);
+							this.status = mockHandler.status[idxStatus];							
+						} else if (typeof mockHandler.status === 'number' || typeof mockHandler.status === 'string') {
+							this.statusText = mockHandler.status;
 						}
 						
 						if( typeof mockHandler.statusText === 'string') {

--- a/src/jquery.mockjax.js
+++ b/src/jquery.mockjax.js
@@ -221,6 +221,13 @@
 
 		return handler;
 	}
+	
+	function getRandomInteger(min, max) {
+		min = Math.ceil(min);
+		max = Math.floor(max);
+		// get a random integer between two values, inclusive
+		return Math.floor(Math.random() * (max - min + 1)) + min;
+	}
 
 	function isPosNum(value) {
 		return typeof value === 'number' && value >= 0;
@@ -275,9 +282,14 @@
 						} else {
 							this.responseText = mockHandler.responseText;
 						}
+						
 						if( typeof mockHandler.status === 'number' || typeof mockHandler.status === 'string' ) {
-							this.status = mockHandler.status;
+							// allow a double pipe-delimited list of strings or numbers, with the plugin randomly returning one of them
+							var arrStatus = (typeof mockHandler.status === 'string' ? mockHandler.status.replace(/\s+/g, '').split('||') : mockHandler.status.toString().split('||'));
+							var idxStatus = getRandomInteger(0,arrStatus.length-1);
+							this.status = arrStatus[idxStatus];
 						}
+						
 						if( typeof mockHandler.statusText === 'string') {
 							this.statusText = mockHandler.statusText;
 						}

--- a/src/jquery.mockjax.js
+++ b/src/jquery.mockjax.js
@@ -221,13 +221,6 @@
 
 		return handler;
 	}
-	
-	function getRandomInteger(min, max) {
-		min = Math.ceil(min);
-		max = Math.floor(max);
-		// get a random integer between two values, inclusive
-		return Math.floor(Math.random() * (max - min + 1)) + min;
-	}
 
 	function isPosNum(value) {
 		return typeof value === 'number' && value >= 0;
@@ -284,7 +277,10 @@
 						}
 						
 						if ($.isArray(mockHandler.status)) {
-							var idxStatus = getRandomInteger(0,mockHandler.status.length-1);
+							var min = Math.ceil(0);
+							var max = Math.floor(mockHandler.status.length-1);
+							// get a random integer between two values, inclusive
+							var idxStatus = Math.floor(Math.random() * (max - min + 1)) + min;
 							this.status = mockHandler.status[idxStatus];							
 						} else if (typeof mockHandler.status === 'number' || typeof mockHandler.status === 'string') {
 							this.status = mockHandler.status;

--- a/src/jquery.mockjax.js
+++ b/src/jquery.mockjax.js
@@ -287,7 +287,7 @@
 							var idxStatus = getRandomInteger(0,mockHandler.status.length-1);
 							this.status = mockHandler.status[idxStatus];							
 						} else if (typeof mockHandler.status === 'number' || typeof mockHandler.status === 'string') {
-							this.statusText = mockHandler.status;
+							this.status = mockHandler.status;
 						}
 						
 						if( typeof mockHandler.statusText === 'string') {

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -251,7 +251,7 @@
 		var done = assert.async();
 		var possibleStatuses = [500,400,404];
 	  	var returnedStatuses = [];
-		var maxNumLoops = possibleStatuses.length * 10;
+		var maxNumLoops = possibleStatuses.length * 0.5;
 		var numLoops = 0;
 		var numLoopsComplete = 0;
 

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -269,7 +269,7 @@
 				assert.ok(true, 'error callback was called');
 			},
 			complete: function(xhr) {
-				assert.notEqual($.inArray(xhr.status, possibleStatuses.split('||'), -1, 'Dynamically set random response status found');
+				assert.notEqual($.inArray(xhr.status, possibleStatuses.split('||')), -1, 'Dynamically set random response status found');
 
 				if( $.fn.jquery !== '1.5.2') {
 					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
@@ -304,7 +304,7 @@
 				assert.ok(true, 'error callback was called');
 			},
 			complete: function(xhr) {
-				assert.notEqual($.inArray(xhr.status, possibleStatuses.toString().split('||'), -1, 'Dynamically set random response status found');
+				assert.notEqual($.inArray(xhr.status, possibleStatuses.toString().split('||')), -1, 'Dynamically set random response status found');
 
 				if( $.fn.jquery !== '1.5.2') {
 					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -251,7 +251,7 @@
 		var done = assert.async();
 		var possibleStatuses = [500,400,404];
 	  	var returnedStatuses = [];
-		var maxNumLoops = possibleStatuses.length - 1;// * 50;
+		var maxNumLoops = possibleStatuses.length * 50;
 		var numLoops = 0;
 		var numLoopsComplete = 0;
 
@@ -321,41 +321,48 @@
 				this.statusText = 'Internal Server Error';
 			}
 		});
+		
+		var completeCallback = function(xhr) {
+			assert.notEqual($.inArray(xhr.status, possibleStatuses), -1, 'Dynamically set random response status found');
 
-		$.ajax({
-			url: '/response-callback',
-			dataType: 'text',
-			data: {
-				response: 'Hello world'
-			},
-			success: function() {
-				assert.ok(true, 'success callback was called');
-			},
-			complete: function(xhr) {
-				assert.notEqual($.inArray(xhr.status, possibleStatuses), -1, 'Dynamically set random response status found');
-
-				if( $.fn.jquery !== '1.5.2') {
-					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
-					// The statusText is being modified internally by jQuery in 1.5.2
-					assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
-				}
-				
-				// add this to our array of returned statuses (if it isn't there already)
-			  	if($.inArray(xhr.status, returnedStatuses) === -1) {
-					returnedStatuses.push(xhr.status);
-			  	}
-				
-			  	// increment counter
-			  	numLoopsComplete++;
-				
-				// if we made it this far without matching all possible statuses, fail!
-  	  			if (numLoopsComplete >= maxNumLoops) {
-  	    			assert.equal(returnedStatuses.length, possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");					
-				}
-				
-				done();
+			if( $.fn.jquery !== '1.5.2') {
+				// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
+				// The statusText is being modified internally by jQuery in 1.5.2
+				assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
 			}
-		});
+
+			// add this to our array of returned statuses (if it isn't there already)
+			if($.inArray(xhr.status, returnedStatuses) === -1) {
+				returnedStatuses.push(xhr.status);
+			}
+
+			// increment counter
+			numLoopsComplete++;
+
+			// if we made it this far without matching all possible statuses, fail!
+			if (numLoopsComplete >= maxNumLoops) {
+				assert.equal(returnedStatuses.length, possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");					
+			}
+
+			done();
+		}
+
+		do {
+			$.ajax({
+				url: '/response-callback',
+				dataType: 'text',
+				data: {
+					response: 'Hello world'
+				},
+				success: function() {
+					assert.ok(true, 'success callback was called');
+				},
+				complete: completeCallback
+			});
+			
+			// increment counter
+		  	numLoops++;
+		  } while (numLoops < maxNumLoops);
 	});
 
 	t('Dynamic response status callback - list of statuses as an array (mix of successes and failures)', function(assert) {
@@ -374,37 +381,44 @@
 			}
 		});
 
-		$.ajax({
-			url: '/response-callback',
-			dataType: 'text',
-			data: {
-				response: 'Hello world'
-			},
-			complete: function(xhr) {
-				assert.notEqual($.inArray(xhr.status, possibleStatuses), -1, 'Dynamically set random response status found');
+		var completeCallback = function(xhr) {
+			assert.notEqual($.inArray(xhr.status, possibleStatuses), -1, 'Dynamically set random response status found');
 
-				if( $.fn.jquery !== '1.5.2') {
-					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
-					// The statusText is being modified internally by jQuery in 1.5.2
-					assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
-				}
-				
-				// add this to our array of returned statuses (if it isn't there already)
-			  	if($.inArray(xhr.status, returnedStatuses) === -1) {
-					returnedStatuses.push(xhr.status);
-			  	}
-				
-			  	// increment counter
-			  	numLoopsComplete++;
-				
-				// if we made it this far without matching all possible statuses, fail!
-  	  			if (numLoopsComplete >= maxNumLoops) {
-  	    			assert.equal(returnedStatuses.length, possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");					
-				}
-				
-				done();
+			if( $.fn.jquery !== '1.5.2') {
+				// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
+				// The statusText is being modified internally by jQuery in 1.5.2
+				assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
 			}
-		});
+
+			// add this to our array of returned statuses (if it isn't there already)
+			if($.inArray(xhr.status, returnedStatuses) === -1) {
+				returnedStatuses.push(xhr.status);
+			}
+
+			// increment counter
+			numLoopsComplete++;
+
+			// if we made it this far without matching all possible statuses, fail!
+			if (numLoopsComplete >= maxNumLoops) {
+				assert.equal(returnedStatuses.length, possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");					
+			}
+
+			done();
+		}
+
+		do {
+			$.ajax({
+				url: '/response-callback',
+				dataType: 'text',
+				data: {
+					response: 'Hello world'
+				},
+				complete: completeCallback
+			});
+			
+			// increment counter
+		  	numLoops++;
+		  } while (numLoops < maxNumLoops);
 	});
 
 	t('Default Response Settings', function(assert) {

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -251,7 +251,7 @@
 		var done = assert.async();
 		var possibleStatuses = [500,400,404];
 	  	var returnedStatuses = [];
-		var maxNumLoops = possibleStatuses.length * 0.25;
+		var maxNumLoops = possibleStatuses.length * 50;
 		var numLoops = 0;
 		var numLoopsComplete = 0;
 
@@ -299,11 +299,11 @@
 		});
 	});
 
-	/*t('Dynamic response status callback - list of statuses as an array (successes only)', function(assert) {
+	t('Dynamic response status callback - list of statuses as an array (successes only)', function(assert) {
 		var done = assert.async();
 		var possibleStatuses = [200,201,204];
 	  	var returnedStatuses = [];
-		var maxNumLoops = possibleStatuses.length * 10;
+		var maxNumLoops = possibleStatuses.length * 50;
 		var numLoops = 0;
 		var numLoopsComplete = 0;
 
@@ -326,6 +326,12 @@
 			},
 			complete: function(xhr) {
 				assert.notEqual($.inArray(xhr.status, possibleStatuses), -1, 'Dynamically set random response status found');
+
+				if( $.fn.jquery !== '1.5.2') {
+					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
+					// The statusText is being modified internally by jQuery in 1.5.2
+					assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
+				}
 				
 				// add this to our array of returned statuses (if it isn't there already)
 			  	if($.inArray(xhr.status, returnedStatuses) === -1) {
@@ -334,28 +340,22 @@
 				
 			  	// increment counter
 			  	numLoopsComplete++;
-
-				if( $.fn.jquery !== '1.5.2') {
-					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
-					// The statusText is being modified internally by jQuery in 1.5.2
-					assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
-				}
 				
 				// if we made it this far without matching all possible statuses, fail!
   	  			if (numLoopsComplete >= maxNumLoops) {
-  	    			assert.ok(returnedStatuses.length === possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");
-  	    
-  		  			done();
+  	    			assert.equal(returnedStatuses.length, possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");					
 				}
+				
+				done();
 			}
 		});
 	});
 
-	t('Dynamic response status callback - list of statuses as an array', function(assert) {
+	t('Dynamic response status callback - list of statuses as an array (mix of successes and failures)', function(assert) {
 		var done = assert.async();
-		var possibleStatuses = [500,400,404,200,201];
+		var possibleStatuses = [200,201,204,400,404,500];
 	  	var returnedStatuses = [];
-		var maxNumLoops = possibleStatuses.length * 10;
+		var maxNumLoops = possibleStatuses.length * 50;
 		var numLoops = 0;
 		var numLoopsComplete = 0;
 
@@ -375,6 +375,12 @@
 			},
 			complete: function(xhr) {
 				assert.notEqual($.inArray(xhr.status, possibleStatuses), -1, 'Dynamically set random response status found');
+
+				if( $.fn.jquery !== '1.5.2') {
+					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
+					// The statusText is being modified internally by jQuery in 1.5.2
+					assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
+				}
 				
 				// add this to our array of returned statuses (if it isn't there already)
 			  	if($.inArray(xhr.status, returnedStatuses) === -1) {
@@ -383,22 +389,16 @@
 				
 			  	// increment counter
 			  	numLoopsComplete++;
-
-				if( $.fn.jquery !== '1.5.2') {
-					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
-					// The statusText is being modified internally by jQuery in 1.5.2
-					assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
-				}
 				
 				// if we made it this far without matching all possible statuses, fail!
   	  			if (numLoopsComplete >= maxNumLoops) {
-  	    			assert.ok(returnedStatuses.length === possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");
-  	    
-  		  			done();
+  	    			assert.equal(returnedStatuses.length, possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");					
 				}
+				
+				done();
 			}
 		});
-	});*/
+	});
 
 	t('Default Response Settings', function(assert) {
 		var done = assert.async();

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -291,7 +291,7 @@
 				
 				// if we made it this far without matching all possible statuses, fail!
   	  			if (numLoopsComplete >= maxNumLoops) {
-  	    			assert.ok(returnedStatuses.length !== possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");
+  	    			assert.ok(returnedStatuses.length === possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");
   	    
   		  			done();
 				}
@@ -299,7 +299,7 @@
 		});
 	});
 
-	t('Dynamic response status callback - list of statuses as an array (successes only)', function(assert) {
+	/*t('Dynamic response status callback - list of statuses as an array (successes only)', function(assert) {
 		var done = assert.async();
 		var possibleStatuses = [200,201,204];
 	  	var returnedStatuses = [];
@@ -398,7 +398,7 @@
 				}
 			}
 		});
-	});
+	});*/
 
 	t('Default Response Settings', function(assert) {
 		var done = assert.async();

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -247,6 +247,76 @@
 		});
 	});
 
+	t('Dynamic response status callback - list of statuses as a string', function(assert) {
+		var done = assert.async();
+		var possibleStatuses = "500||400||200";
+
+		$.mockjax({
+			url: '/response-callback',
+			response: function() {
+				this.status = possibleStatuses;
+				this.statusText = 'Internal Server Error';
+			}
+		});
+
+		$.ajax({
+			url: '/response-callback',
+			dataType: 'text',
+			data: {
+				response: 'Hello world'
+			},
+			error: function() {
+				assert.ok(true, 'error callback was called');
+			},
+			complete: function(xhr) {
+				assert.notEqual($.inArray(xhr.status, possibleStatuses.split('||'), -1, 'Dynamically set random response status found');
+
+				if( $.fn.jquery !== '1.5.2') {
+					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
+					// The statusText is being modified internally by jQuery in 1.5.2
+					assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
+				}
+
+				done();
+			}
+		});
+	});
+
+	t('Dynamic response status callback - list of statuses as a number', function(assert) {
+		var done = assert.async();
+		var possibleStatuses = 500||400||200;
+
+		$.mockjax({
+			url: '/response-callback',
+			response: function() {
+				this.status = possibleStatuses;
+				this.statusText = 'Internal Server Error';
+			}
+		});
+
+		$.ajax({
+			url: '/response-callback',
+			dataType: 'text',
+			data: {
+				response: 'Hello world'
+			},
+			error: function() {
+				assert.ok(true, 'error callback was called');
+			},
+			complete: function(xhr) {
+				assert.notEqual($.inArray(xhr.status, possibleStatuses.toString().split('||'), -1, 'Dynamically set random response status found');
+
+				if( $.fn.jquery !== '1.5.2') {
+					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
+					// The statusText is being modified internally by jQuery in 1.5.2
+					assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
+				}
+
+				done();
+			}
+		});
+	});
+
 	t('Default Response Settings', function(assert) {
 		var done = assert.async();
 

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -262,41 +262,48 @@
 				this.statusText = 'Internal Server Error';
 			}
 		});
+		
+		var completeCallback = function(xhr) {
+			assert.notEqual($.inArray(xhr.status, possibleStatuses), -1, 'Dynamically set random response status found');
 
-		$.ajax({
-			url: '/response-callback',
-			dataType: 'text',
-			data: {
-				response: 'Hello world'
-			},
-			error: function() {
-				assert.ok(true, 'error callback was called');
-			},
-			complete: function(xhr) {
-				assert.notEqual($.inArray(xhr.status, possibleStatuses), -1, 'Dynamically set random response status found');
-
-				if( $.fn.jquery !== '1.5.2') {
-					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
-					// The statusText is being modified internally by jQuery in 1.5.2
-					assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
-				}
-				
-				// add this to our array of returned statuses (if it isn't there already)
-			  	if($.inArray(xhr.status, returnedStatuses) === -1) {
-					returnedStatuses.push(xhr.status);
-			  	}
-				
-			  	// increment counter
-			  	numLoopsComplete++;
-				
-				// if we made it this far without matching all possible statuses, fail!
-  	  			if (numLoopsComplete >= maxNumLoops) {
-  	    			assert.equal(returnedStatuses.length, possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");					
-				}
-				
-				done();
+			if( $.fn.jquery !== '1.5.2') {
+				// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
+				// The statusText is being modified internally by jQuery in 1.5.2
+				assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
 			}
-		});
+
+			// add this to our array of returned statuses (if it isn't there already)
+			if($.inArray(xhr.status, returnedStatuses) === -1) {
+				returnedStatuses.push(xhr.status);
+			}
+
+			// increment counter
+			numLoopsComplete++;
+
+			// if we made it this far without matching all possible statuses, fail!
+			if (numLoopsComplete >= maxNumLoops) {
+				assert.equal(returnedStatuses.length, possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");					
+			}
+
+			done();
+		}
+
+		do {
+			$.ajax({
+				url: '/response-callback',
+				dataType: 'text',
+				data: {
+					response: 'Hello world'
+				},
+				error: function() {
+					assert.ok(true, 'error callback was called');
+				},
+				complete: completeCallback
+			});
+			
+			// increment counter
+		  	numLoops++;
+		  } while (numLoops < maxNumLoops);
 	});
 
 	t('Dynamic response status callback - list of statuses as an array (successes only)', function(assert) {

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -202,7 +202,7 @@
 				url: '/response',
 				success: function() {
 					assert.ok(arguments[2], 'there is a third argument to the success callback');
-					assert.equal(arguments[2].status, 200, 'third argument has proper status code');
+					assert.ok(arguments[2] && arguments[2].status === 200, 'third argument has proper status code');
 					done();
 				},
 				error: function() {
@@ -247,9 +247,13 @@
 		});
 	});
 
-	t('Dynamic response status callback - list of statuses as a string', function(assert) {
+	t('Dynamic response status callback - list of statuses as an array (errors only)', function(assert) {
 		var done = assert.async();
-		var possibleStatuses = [500,400,200];
+		var possibleStatuses = [500,400,404];
+	  	var returnedStatuses = [];
+		var maxNumLoops = possibleStatuses.length * 10;
+		var numLoops = 0;
+		var numLoopsComplete = 0;
 
 		$.mockjax({
 			url: '/response-callback',
@@ -270,14 +274,128 @@
 			},
 			complete: function(xhr) {
 				assert.notEqual($.inArray(xhr.status, possibleStatuses), -1, 'Dynamically set random response status found');
+				
+				// add this to our array of returned statuses (if it isn't there already)
+			  	if($.inArray(xhr.status, returnedStatuses) === -1) {
+					returnedStatuses.push(xhr.status);
+			  	}
+				
+			  	// increment counter
+			  	numLoopsComplete++;
 
 				if( $.fn.jquery !== '1.5.2') {
 					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
 					// The statusText is being modified internally by jQuery in 1.5.2
 					assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
 				}
+				
+				// if we made it this far without matching all possible statuses, fail!
+  	  			if (numLoopsComplete >= maxNumLoops) {
+  	    			assert.ok(returnedStatuses.length !== possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");
+  	    
+  		  			done();
+				}
+			}
+		});
+	});
 
-				done();
+	t('Dynamic response status callback - list of statuses as an array (successes only)', function(assert) {
+		var done = assert.async();
+		var possibleStatuses = [200,201,204];
+	  	var returnedStatuses = [];
+		var maxNumLoops = possibleStatuses.length * 10;
+		var numLoops = 0;
+		var numLoopsComplete = 0;
+
+		$.mockjax({
+			url: '/response-callback',
+			response: function() {
+				this.status = possibleStatuses;
+				this.statusText = 'Internal Server Error';
+			}
+		});
+
+		$.ajax({
+			url: '/response-callback',
+			dataType: 'text',
+			data: {
+				response: 'Hello world'
+			},
+			success: function() {
+				assert.ok(true, 'success callback was called');
+			},
+			complete: function(xhr) {
+				assert.notEqual($.inArray(xhr.status, possibleStatuses), -1, 'Dynamically set random response status found');
+				
+				// add this to our array of returned statuses (if it isn't there already)
+			  	if($.inArray(xhr.status, returnedStatuses) === -1) {
+					returnedStatuses.push(xhr.status);
+			  	}
+				
+			  	// increment counter
+			  	numLoopsComplete++;
+
+				if( $.fn.jquery !== '1.5.2') {
+					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
+					// The statusText is being modified internally by jQuery in 1.5.2
+					assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
+				}
+				
+				// if we made it this far without matching all possible statuses, fail!
+  	  			if (numLoopsComplete >= maxNumLoops) {
+  	    			assert.ok(returnedStatuses.length !== possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");
+  	    
+  		  			done();
+				}
+			}
+		});
+	});
+
+	t('Dynamic response status callback - list of statuses as an array', function(assert) {
+		var done = assert.async();
+		var possibleStatuses = [500,400,404,200,201];
+	  	var returnedStatuses = [];
+		var maxNumLoops = possibleStatuses.length * 10;
+		var numLoops = 0;
+		var numLoopsComplete = 0;
+
+		$.mockjax({
+			url: '/response-callback',
+			response: function() {
+				this.status = possibleStatuses;
+				this.statusText = 'Internal Server Error';
+			}
+		});
+
+		$.ajax({
+			url: '/response-callback',
+			dataType: 'text',
+			data: {
+				response: 'Hello world'
+			},
+			complete: function(xhr) {
+				assert.notEqual($.inArray(xhr.status, possibleStatuses), -1, 'Dynamically set random response status found');
+				
+				// add this to our array of returned statuses (if it isn't there already)
+			  	if($.inArray(xhr.status, returnedStatuses) === -1) {
+					returnedStatuses.push(xhr.status);
+			  	}
+				
+			  	// increment counter
+			  	numLoopsComplete++;
+
+				if( $.fn.jquery !== '1.5.2') {
+					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
+					// The statusText is being modified internally by jQuery in 1.5.2
+					assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
+				}
+				
+				// if we made it this far without matching all possible statuses, fail!
+  	  			if (numLoopsComplete >= maxNumLoops) {
+  	    			assert.ok(returnedStatuses.length !== possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");
+  	    
+  		  			done();
+				}
 			}
 		});
 	});

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -269,7 +269,7 @@
 				assert.ok(true, 'error callback was called');
 			},
 			complete: function(xhr) {
-				assert.notEqual($.inArray(xhr.status, possibleStatuses.split('||')), -1, 'Dynamically set random response status found');
+				assert.notEqual($.inArray(xhr.status, possibleStatuses), -1, 'Dynamically set random response status found');
 
 				if( $.fn.jquery !== '1.5.2') {
 					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -252,7 +252,6 @@
 		var possibleStatuses = [200,201,204,400,404,500];
 	  	var returnedStatuses = [];
 		var maxNumLoops = possibleStatuses.length * 50;
-		var numLoops = 0;
 		var numLoopsComplete = 0;
 
 		$.mockjax({
@@ -297,10 +296,7 @@
 				},
 				complete: completeCallback
 			});
-			
-			// increment counter
-		  	numLoops++;
-		  } while ((numLoops < maxNumLoops) && (possibleStatuses.length !== returnedStatuses.length));
+		  } while ((numLoopsComplete < maxNumLoops) && (possibleStatuses.length !== returnedStatuses.length));
 	});
 
 	t('Default Response Settings', function(assert) {

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -200,9 +200,9 @@
 			$.ajax({
 				type: 'GET',
 				url: '/response',
-				success: function(data, textStatus, jqXHR) {
+				success: function() {
 					assert.ok(arguments[2], 'there is a third argument to the success callback');
-					assert.equal(xhr.status, 200, 'third argument has proper status code');
+					assert.equal(arguments[2].status, 200, 'third argument has proper status code');
 					done();
 				},
 				error: function() {

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -283,9 +283,9 @@
 			// if we made it this far without matching all possible statuses, fail!
 			if (numLoopsComplete >= maxNumLoops) {
 				assert.equal(returnedStatuses.length, possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");					
+				
+				done();
 			}
-
-			done();
 		}
 
 		do {
@@ -342,9 +342,9 @@
 			// if we made it this far without matching all possible statuses, fail!
 			if (numLoopsComplete >= maxNumLoops) {
 				assert.equal(returnedStatuses.length, possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");					
+				
+				done();
 			}
-
-			done();
 		}
 
 		do {
@@ -401,9 +401,9 @@
 			// if we made it this far without matching all possible statuses, fail!
 			if (numLoopsComplete >= maxNumLoops) {
 				assert.equal(returnedStatuses.length, possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");					
+				
+				done();
 			}
-
-			done();
 		}
 
 		do {

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -200,9 +200,9 @@
 			$.ajax({
 				type: 'GET',
 				url: '/response',
-				success: function() {
+				success: function(data, textStatus, jqXHR) {
 					assert.ok(arguments[2], 'there is a third argument to the success callback');
-					assert.ok(arguments[2] && arguments[2].status === 200, 'third argument has proper status code');
+					assert.equal(xhr.status, 200, 'third argument has proper status code');
 					done();
 				},
 				error: function() {

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -247,124 +247,6 @@
 		});
 	});
 
-	t('Dynamic response status callback - list of statuses as an array (errors only)', function(assert) {
-		var done = assert.async();
-		var possibleStatuses = [500,400,404];
-	  	var returnedStatuses = [];
-		var maxNumLoops = possibleStatuses.length * 50;
-		var numLoops = 0;
-		var numLoopsComplete = 0;
-
-		$.mockjax({
-			url: '/response-callback',
-			response: function() {
-				this.status = possibleStatuses;
-				this.statusText = 'Internal Server Error';
-			}
-		});
-		
-		var completeCallback = function(xhr) {
-			assert.notEqual($.inArray(xhr.status, possibleStatuses), -1, 'Dynamically set random response status found');
-
-			if( $.fn.jquery !== '1.5.2') {
-				// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
-				// The statusText is being modified internally by jQuery in 1.5.2
-				assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
-			}
-
-			// add this to our array of returned statuses (if it isn't there already)
-			if($.inArray(xhr.status, returnedStatuses) === -1) {
-				returnedStatuses.push(xhr.status);
-			}
-
-			// increment counter
-			numLoopsComplete++;
-
-			// if we made it this far without matching all possible statuses, fail!
-			if (numLoopsComplete >= maxNumLoops) {
-				assert.equal(returnedStatuses.length, possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");					
-				
-				done();
-			}
-		}
-
-		do {
-			$.ajax({
-				url: '/response-callback',
-				dataType: 'text',
-				data: {
-					response: 'Hello world'
-				},
-				error: function() {
-					assert.ok(true, 'error callback was called');
-				},
-				complete: completeCallback
-			});
-			
-			// increment counter
-		  	numLoops++;
-		  } while (numLoops < maxNumLoops);
-	});
-
-	t('Dynamic response status callback - list of statuses as an array (successes only)', function(assert) {
-		var done = assert.async();
-		var possibleStatuses = [200,201,204];
-	  	var returnedStatuses = [];
-		var maxNumLoops = possibleStatuses.length * 50;
-		var numLoops = 0;
-		var numLoopsComplete = 0;
-
-		$.mockjax({
-			url: '/response-callback',
-			response: function() {
-				this.status = possibleStatuses;
-				this.statusText = 'Internal Server Error';
-			}
-		});
-		
-		var completeCallback = function(xhr) {
-			assert.notEqual($.inArray(xhr.status, possibleStatuses), -1, 'Dynamically set random response status found');
-
-			if( $.fn.jquery !== '1.5.2') {
-				// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
-				// The statusText is being modified internally by jQuery in 1.5.2
-				assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
-			}
-
-			// add this to our array of returned statuses (if it isn't there already)
-			if($.inArray(xhr.status, returnedStatuses) === -1) {
-				returnedStatuses.push(xhr.status);
-			}
-
-			// increment counter
-			numLoopsComplete++;
-
-			// if we made it this far without matching all possible statuses, fail!
-			if (numLoopsComplete >= maxNumLoops) {
-				assert.equal(returnedStatuses.length, possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");					
-				
-				done();
-			}
-		}
-
-		do {
-			$.ajax({
-				url: '/response-callback',
-				dataType: 'text',
-				data: {
-					response: 'Hello world'
-				},
-				success: function() {
-					assert.ok(true, 'success callback was called');
-				},
-				complete: completeCallback
-			});
-			
-			// increment counter
-		  	numLoops++;
-		  } while (numLoops < maxNumLoops);
-	});
-
 	t('Dynamic response status callback - list of statuses as an array (mix of successes and failures)', function(assert) {
 		var done = assert.async();
 		var possibleStatuses = [200,201,204,400,404,500];
@@ -383,12 +265,6 @@
 
 		var completeCallback = function(xhr) {
 			assert.notEqual($.inArray(xhr.status, possibleStatuses), -1, 'Dynamically set random response status found');
-
-			if( $.fn.jquery !== '1.5.2') {
-				// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
-				// The statusText is being modified internally by jQuery in 1.5.2
-				assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
-			}
 
 			// add this to our array of returned statuses (if it isn't there already)
 			if($.inArray(xhr.status, returnedStatuses) === -1) {

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -249,7 +249,7 @@
 
 	t('Dynamic response status callback - list of statuses as a string', function(assert) {
 		var done = assert.async();
-		var possibleStatuses = "500||400||200";
+		var possibleStatuses = [500,400,200];
 
 		$.mockjax({
 			url: '/response-callback',
@@ -270,41 +270,6 @@
 			},
 			complete: function(xhr) {
 				assert.notEqual($.inArray(xhr.status, possibleStatuses.split('||')), -1, 'Dynamically set random response status found');
-
-				if( $.fn.jquery !== '1.5.2') {
-					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
-					// The statusText is being modified internally by jQuery in 1.5.2
-					assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
-				}
-
-				done();
-			}
-		});
-	});
-
-	t('Dynamic response status callback - list of statuses as a number', function(assert) {
-		var done = assert.async();
-		var possibleStatuses = 500||400||200;
-
-		$.mockjax({
-			url: '/response-callback',
-			response: function() {
-				this.status = possibleStatuses;
-				this.statusText = 'Internal Server Error';
-			}
-		});
-
-		$.ajax({
-			url: '/response-callback',
-			dataType: 'text',
-			data: {
-				response: 'Hello world'
-			},
-			error: function() {
-				assert.ok(true, 'error callback was called');
-			},
-			complete: function(xhr) {
-				assert.notEqual($.inArray(xhr.status, possibleStatuses.toString().split('||')), -1, 'Dynamically set random response status found');
 
 				if( $.fn.jquery !== '1.5.2') {
 					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -280,6 +280,11 @@
 				
 				done();
 			}
+			
+			// we short-circuited early, so we can be done
+			if (returnedStatuses.length === possibleStatuses.length) {
+				done();	
+			}
 		}
 
 		do {

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -292,9 +292,9 @@
 				// if we made it this far without matching all possible statuses, fail!
   	  			if (numLoopsComplete >= maxNumLoops) {
   	    			assert.ok(returnedStatuses.length === possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");
+					
+					done();
 				}
-  	    
-  		  		done();
 			}
 		});
 	});

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -251,7 +251,7 @@
 		var done = assert.async();
 		var possibleStatuses = [500,400,404];
 	  	var returnedStatuses = [];
-		var maxNumLoops = possibleStatuses.length * 0.5;
+		var maxNumLoops = possibleStatuses.length * 0.25;
 		var numLoops = 0;
 		var numLoopsComplete = 0;
 
@@ -274,6 +274,12 @@
 			},
 			complete: function(xhr) {
 				assert.notEqual($.inArray(xhr.status, possibleStatuses), -1, 'Dynamically set random response status found');
+
+				if( $.fn.jquery !== '1.5.2') {
+					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
+					// The statusText is being modified internally by jQuery in 1.5.2
+					assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
+				}
 				
 				// add this to our array of returned statuses (if it isn't there already)
 			  	if($.inArray(xhr.status, returnedStatuses) === -1) {
@@ -282,19 +288,13 @@
 				
 			  	// increment counter
 			  	numLoopsComplete++;
-
-				if( $.fn.jquery !== '1.5.2') {
-					// This assertion fails in 1.5.2 due to this bug: http://bugs.jquery.com/ticket/9854
-					// The statusText is being modified internally by jQuery in 1.5.2
-					assert.equal(xhr.statusText, 'Internal Server Error', 'Dynamically set response statusText matches');
-				}
 				
 				// if we made it this far without matching all possible statuses, fail!
   	  			if (numLoopsComplete >= maxNumLoops) {
-  	    			assert.ok(returnedStatuses.length === possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");
-					
-					done();
+  	    			assert.equal(returnedStatuses.length, possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");					
 				}
+				
+				done();
 			}
 		});
 	});

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -251,7 +251,7 @@
 		var done = assert.async();
 		var possibleStatuses = [500,400,404];
 	  	var returnedStatuses = [];
-		var maxNumLoops = possibleStatuses.length * 50;
+		var maxNumLoops = possibleStatuses.length - 1;// * 50;
 		var numLoops = 0;
 		var numLoopsComplete = 0;
 

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -292,9 +292,9 @@
 				// if we made it this far without matching all possible statuses, fail!
   	  			if (numLoopsComplete >= maxNumLoops) {
   	    			assert.ok(returnedStatuses.length === possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");
-  	    
-  		  			done();
 				}
+  	    
+  		  		done();
 			}
 		});
 	});
@@ -343,7 +343,7 @@
 				
 				// if we made it this far without matching all possible statuses, fail!
   	  			if (numLoopsComplete >= maxNumLoops) {
-  	    			assert.ok(returnedStatuses.length !== possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");
+  	    			assert.ok(returnedStatuses.length === possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");
   	    
   		  			done();
 				}
@@ -392,7 +392,7 @@
 				
 				// if we made it this far without matching all possible statuses, fail!
   	  			if (numLoopsComplete >= maxNumLoops) {
-  	    			assert.ok(returnedStatuses.length !== possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");
+  	    			assert.ok(returnedStatuses.length === possibleStatuses.length, "Did not randomly return all possible statuses (only returned: " + returnedStatuses.toString() + ")");
   	    
   		  			done();
 				}

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -286,6 +286,7 @@
 			$.ajax({
 				url: '/response-callback',
 				dataType: 'text',
+				async: false,
 				data: {
 					response: 'Hello world'
 				},
@@ -294,7 +295,7 @@
 			
 			// increment counter
 		  	numLoops++;
-		  } while (numLoops < maxNumLoops);
+		  } while ((numLoops < maxNumLoops) && (possibleStatuses.length !== returnedStatuses.length));
 	});
 
 	t('Default Response Settings', function(assert) {


### PR DESCRIPTION
(piggy-backing on an existing [closed issue](https://github.com/jakerella/jquery-mockjax/issues/222), which I had commented on as well)

I have a page which contains a large data grid (using the jQuery DataTables plugin), and I wanted to simulate getting random errors when performing an action (e.g., delete a record in the table). Hooking into the response meant that once the page loaded/that the mock was built, I always got the same response for every delete call (e.g., I could set a random status value - 200, 400, 500, etc. - but that "random" response was always the same for every call on that page, instead of being a random status between individual calls once the page was loaded). 

Add in this function:
```
function getRandomInteger(min, max) {
	min = Math.ceil(min);
	max = Math.floor(max);
	// get a random integer between two values, inclusive
	return Math.floor(Math.random() * (max - min + 1)) + min;
}
```

Then replace this:
```
if( typeof mockHandler.status === 'number' || typeof mockHandler.status === 'string' ) {
	this.status = mockHandler.status;
}
```

With this:
```
if( typeof mockHandler.status === 'number' || typeof mockHandler.status === 'string' ) {
	var arrStatus = (typeof mockHandler.status === 'string' ? 
		mockHandler.status.replace(/\s+/g, '').split('||') : 
		mockHandler.status.toString().split('||'));
	var idxStatus = getRandomInteger(0,arrStatus.length-1);
	this.status = arrStatus[idxStatus];
}
```

This would allow existing functionality (provide a literal number or string as the response status), as well as offering up a list for the plugin to randomly pick from:

```
// delete a specific group - always succeed
$.mockjax({
	url: '*/Groups/*',
	type: 'DELETE',
	status: '200'
});

// delete a specific group - randomly fail
// separate individual responses with a double pipe
$.mockjax({
	url: '*/Groups/*',
	type: 'DELETE',
	status: '200||400||500'
});

// delete a specific group - randomly fail (with a preference towards success)
$.mockjax({
	url: '*/Groups/*',
	type: 'DELETE',
	status: '200||400||200||500||200'
});
```