### PR TITLE
Add `handlers()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@ checkout this list:
       * `onAfterError`: [Function] A callback that will be called after the error method has been called, this is useful to check a condition after the call has been completed
       * `onAfterComplete`: [Function] Similar to onAfterSuccess, but will be executed after the complete method has been called
 * `Object $.mockjax.handler(/* Number */ id)`
-  * Returns the mock request settings for the handler with the provided `id`
+  * Returns the mock request settings for the handler with the provided `id`. Be careful here, you're accessing the inner workings of the plugin, any changes to this object could be bad.
+* `Array $.mockjax.handlers()`
+  * Returns the array of mock handlers. **NOTE:** This array is NOT modified when a handler is cleared, the cleared handler position is simply set to `null`. As such, the array length will only change when new mocks are added. Be careful here, you're accessing the inner workings of the plugin, any changes to the array could be very bad.
 * `void $.mockjax.clear([/* Number */ id])`
   * If the `id` is provided, the handler with that ID is cleared (that is, requests matching it will no longer do so, the handler is completely removed)
   * If no `id` is provided, all handlers are cleared, resetting Mockjax to its initial state

--- a/src/jquery.mockjax.js
+++ b/src/jquery.mockjax.js
@@ -957,6 +957,24 @@
 	};
 
 	/**
+	 * Retrieve the current array of mock handlers.
+	 * NOTE: Altering these handlers, or the array itself is probably not a good
+	 * idea! This could easily lead to malfunction of the library. If you need
+	 * to alter a handler, clear(index) it (using the array index) and then
+	 * create a new handler with $.mockjax({ ... })
+	 *
+	 * **WARNING**: Additionally, note that the handlers array WILL NOT CHANGE
+	 * when a mock is cleared. This is because we have to maintain the handler
+	 * indeces for clearing of other mock handlers. (This is not ideal, and
+	 * will probably change in the future.) Cleared mocks are set to null!
+	 *
+ 	 * @return {Array} The current collection of handlers
+	 */
+	$.mockjax.handlers = function() {
+		return mockHandlers;
+	}
+
+	/**
 	 * Retrieve all Ajax calls that have been mocked by this library during the
 	 * current session (in other words, only since you last loaded this file).
 	 *

--- a/test/test-core.js
+++ b/test/test-core.js
@@ -497,6 +497,42 @@
 		assert.ok($.mockjax.handler(ID).fired, 'Sets the mock\'s fired property to true');
 	});
 
+	t('Inspecting $.mockjax.handlers() for type and length', function(assert) {
+		assert.ok(Array.isArray($.mockjax.handlers()), 'The list of handlers is an array before any mocks');
+		assert.strictEqual($.mockjax.handlers().length, 0, 'The list of handlers is empty before any mocks');
+
+		$.mockjax({ url: '/foo', responseText: 'Hello Word' });
+
+		assert.ok(Array.isArray($.mockjax.handlers()), 'The list of handlers is an array after adding a mock');
+		assert.strictEqual($.mockjax.handlers().length, 1, 'The length of the list of handlers is correct after adding a mock');
+
+		$.mockjax({ url: '/bar', responseText: 'Hello Word' });
+		$.mockjax({ url: '/bat', responseText: 'Hello Word' });
+		$.mockjax({ url: '/baz', responseText: 'Hello Word' });
+
+		assert.ok(Array.isArray($.mockjax.handlers()), 'The list of handlers is an array after adding many mocks');
+		assert.strictEqual($.mockjax.handlers().length, 4, 'The length of the list of handlers is correct after adding many mocks');
+	});
+
+	t('Testing $.mockjax.handlers() after clearing', function(assert) {
+		$.mockjax({ url: '/foo', responseText: 'Hello Word' });
+		$.mockjax({ url: '/bar', responseText: 'Hello Word' });
+		$.mockjax({ url: '/bat', responseText: 'Hello Word' });
+		$.mockjax({ url: '/baz', responseText: 'Hello Word' });
+
+		assert.ok(Array.isArray($.mockjax.handlers()), 'The list of handlers is an array after adding mocks');
+		assert.strictEqual($.mockjax.handlers().length, 4, 'The length of the list of handlers is correct after adding mocks');
+
+		$.mockjax.clear(1);
+
+		assert.ok(Array.isArray($.mockjax.handlers()), 'The list of handlers is an array after clearing mock');
+		assert.strictEqual($.mockjax.handlers().length, 4, 'The length of the list of handlers is correct after clearing mock');
+		assert.strictEqual($.mockjax.handlers()[0].url, '/foo', 'The first handler is correct after clearing');
+		assert.strictEqual($.mockjax.handlers()[1], null, 'The cleared handler is correct after clearing');
+		assert.strictEqual($.mockjax.handlers()[3].url, '/baz', 'The last handler is correct after clearing');
+	});
+
+
 	t('Inspecting $.mockjax() with multiple mocks argument', function(assert) {
 		var done = assert.async();
 		var handlers = $.mockjax([


### PR DESCRIPTION
This PR addresses #321 pretty simply. Note that this is a pretty low-level method, and people should be *very careful* when using it. Read the docs!