### PR TITLE
Fix browserstack testing

### DIFF
--- a/browserstack-config.js
+++ b/browserstack-config.js
@@ -10,12 +10,12 @@ module.exports = {
     "test_path": urls,
     "test_server_port": 3000,
     "browsers": [
-        // "chrome_latest",
-        // "firefox_latest",
-        // "safari_latest",
-        "edge_latest" //,
-        // "ie_9",
-        // "ie_10",
-        // "ie_11"
+        "chrome_latest",
+        "firefox_latest",
+        "safari_latest",
+        "edge_latest",
+        "ie_9",
+        "ie_10",
+        "ie_11"
     ]
 };

--- a/browserstack-config.js
+++ b/browserstack-config.js
@@ -1,7 +1,7 @@
 
 var config = require('./grunt-config-options');
 config.onlyPaths = true;
-var urls = require('./test/build-version-urls')(config, 'latestInBranch', 'all');
+var urls = require('./test/build-version-urls')(config, 'latestInBranch', 'all', 'logging');
 
 module.exports = {
     "username": "jordankasper2",
@@ -10,12 +10,12 @@ module.exports = {
     "test_path": urls,
     "test_server_port": 3000,
     "browsers": [
-        "chrome_latest",
-        "firefox_latest",
-        "safari_latest",
-        "edge_latest",
-        "ie_9",
-        "ie_10",
-        "ie_11"
+        // "chrome_latest",
+        // "firefox_latest",
+        // "safari_latest",
+        "edge_latest" //,
+        // "ie_9",
+        // "ie_10",
+        // "ie_11"
     ]
 };

--- a/test/add-tests.js
+++ b/test/add-tests.js
@@ -4,6 +4,7 @@
 
     var i, l,
         parts = document.location.search.match( /testFiles=([^&]+)/ ),
+        ignore = document.location.search.match( /ignoreFiles=([^&]+)/ ),
         testFiles = [
             'core',  // This will become: <script src='test-core.js'></script>
             'data-match',
@@ -23,10 +24,26 @@
 
     if ( parts && parts[1] ) {
         try {
-            testFiles = JSON.parse( decodeURIComponent(parts[ 1 ]) ) || testFiles;
+            var inputFiles = JSON.parse( decodeURIComponent(parts[ 1 ]) ) || null;
+            if (inputFiles && inputFiles.length && inputFiles[0] !== 'all') {
+                testFiles = inputFiles;
+            }
         } catch(err) {
             console.warn('\n WARNING: Unable to parse the test modules you wanted:', err);
             testFiles = [];
+        }
+    }
+
+    if ( ignore && ignore[1] ) {
+        try {
+            var ignoreFiles = JSON.parse( decodeURIComponent(ignore[ 1 ]) ) || null;
+            if (ignoreFiles && ignoreFiles.length) {
+                testFiles = testFiles.filter(function(file) {
+                    return ignoreFiles.indexOf(file) === -1;
+                });
+            }
+        } catch(err) {
+            console.warn('\n WARNING: Unable to parse the test modules you wanted to ignore:', err);
         }
     }
 

--- a/test/build-version-urls.js
+++ b/test/build-version-urls.js
@@ -1,7 +1,7 @@
 
 var PORT = 4000;
 
-module.exports = function buildVersionURLs(config, arg1, arg2, arg3) {
+module.exports = function buildVersionURLs(config, arg1, arg2, arg3, arg4) {
 
     var gruntConfig = (config.get && config.get()) || config;
 
@@ -9,6 +9,7 @@ module.exports = function buildVersionURLs(config, arg1, arg2, arg3) {
         baseURL = 'http://localhost:' + PORT,
         versionUrls = [],
         testFiles = arg2 || null,
+        ignoreFiles = arg3 || null,
         source = arg1 || 'all',
         versions = (gruntConfig.test[source] && gruntConfig.test[source].jQueryVersions) || [],
         file = (gruntConfig.test[source] && gruntConfig.test[source].file) || 'index.html';
@@ -16,19 +17,23 @@ module.exports = function buildVersionURLs(config, arg1, arg2, arg3) {
     if (arg1 === 'version' && arg2) {
         versions = [arg2];
         testFiles = (arg3) ? arg3 : null;
+        ignoreFiles = (arg4) ? arg4 : null;
     }
 
     if (testFiles) {
         testFiles = JSON.stringify(testFiles.split(/\,/));
     }
+    if (ignoreFiles) {
+        ignoreFiles = JSON.stringify(ignoreFiles.split(/\,/));
+    }
 
     for (i=0, l=versions.length; i<l; ++i) {
         if (arg1 === 'requirejs') {
-            url = 'test/requirejs/' + file + '?jquery=' + versions[i] + '&testFiles=' + testFiles;
+            url = 'test/requirejs/' + file + '?jquery=' + versions[i] + '&testFiles=' + testFiles + '&ignoreFiles=' + ignoreFiles;
             versionUrls.push( url );
             if (!config.onlyPaths) { url = baseURL + '/' + url; }
         } else {
-            url = 'test/' + file + '?jquery=' + versions[i] + '&testFiles=' + testFiles;
+            url = 'test/' + file + '?jquery=' + versions[i] + '&testFiles=' + testFiles + '&ignoreFiles=' + ignoreFiles;
             if (!config.onlyPaths) { url = baseURL + '/' + url; }
             versionUrls.push( url );
         }


### PR DESCRIPTION
Browserstack must do something weird with console logs because our tests on overwriting the console object are failing with a timeout but run fine in a browser and in the terminal. This PR adds an option to ignore some tests, which we do on browserstack only (all tests still run in Travis).